### PR TITLE
Regroup/expand installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ For new users, we recommend running the tutorials first, to see `PyEarthTools` i
 
 The following instructions assume that you have access to [Conda](https://docs.conda.io/projects/conda/en/latest/index.html) on your system.
 
-> [!Note] Windows Users
-> These instructions have been tested on Linux and macOS. We have not tested them on Windows.
-> We welcome any contribution to improve this situation :smile:.
+> [!WARNING]
+> These instructions have been tested on Linux and macOS. We have not tested them on **Windows**.
+> We welcome any contribution to improve this situation 🙂.
 
 First clone this repository and switch to the tutorials folder:
 

--- a/README.md
+++ b/README.md
@@ -62,48 +62,43 @@ pip install -r requirements-dev.txt
 
 > [!WARNING]
 > We do recommend using a Python virtual environment or a Conda environment when developing, to isolate this installation from the rest of your system.
-> Examples are provided in the [Tutorials](#tutorials) section.
 
 
 # Tutorials
 
-First clone the repository:
+For new users, we recommend running the tutorials first, to see `PyEarthTools` in action and get familiar with it.
+
+The following instructions assume that you have access to [Conda](https://docs.conda.io/projects/conda/en/latest/index.html) on your system.
+
+> [!Note] Windows Users
+> These instructions have been tested on Linux and macOS. We have not tested them on Windows.
+> We welcome any contribution to improve this situation :smile:.
+
+First clone this repository and switch to the tutorials folder:
 
 ```
 git clone https://github.com/ACCESS-Community-Hub/PyEarthTools.git
-cd pyearthtools
+cd PyEarthTools/packages/tutorial
 ```
 
-Then create a Python virtual environment:
+Then create a Conda environment to install all dependencies:
 
 ```
-python3 -m venv venv
-venv/bin/activate
+conda env create -f environment.yml -p ./venv
 ```
 
-or a Conda environment to install all dependencies:
+Next, to run the example [notebooks](PyEarthTools/packages/tutorial/nbook/), you can either
+
+- start a JupyterLab instance
 
 ```
-conda create -p ./venv -y python=3.11
 conda activate ./venv
+jupyter lab
 ```
 
-And install all dependencies via pip:
+- or install a Jupyter kernel to use in a pre-existing JupyterLab installation
 
 ```
-pip install -r requirements-dev.txt
-```
-
-You can run some of the tests to check that your installation worked:
-
-```
-pytest packages/data/tests/
-```
-
-To run example [notebooks from the tutorial package](packages/tutorial/nbook), you may need to also install a Jupyter kernel for your environment:
-
-```
-# from the activate virtual or conda environment
-pip install ipykernel
-python -m ipykernel install --user --name pyearthtools
+conda activate ./venv
+python -m ipykernel install --user --name PET-tutorial
 ```

--- a/README.md
+++ b/README.md
@@ -11,27 +11,66 @@
 > to change in the next few months.
 >
 
-# New User Information
+# Getting Started
 
-Guidelines for new users still need to be developed. For those looking to get started, follow the installation instructions below in this README, and then head to the tutorial sub-package to get going.
-
-When this repository is ready for wider use, the intention is to release PyEarthTools on PyPI and conda-forge.
-
-# Repository Layout
-
-This is a so-called monorepo. PyEarthTools comprises multiple, modular packages within a shared namespace that inter-operate in order to provide the overall functionality of the framework. It is not necessary to install all of them, and it is envisioned that many users are likely to want only some parts of the framework. As such, each sub-package is a fully independent Python package, with its own requirements and its own installation process.
-
-Each of these sub-packages lies in the 'packages' subdirectory. Developers of `PyEarthTools` will most likely want to check out the entire monorepo and work on changesets which may span sub-packages. Each sub-package is versioned separately, so bugfixes or updates in a single sub-package can be performed independently without requiring a new release of the entire ecosystem. 
-
-For simplicity, the instructions here explain how to check out the whole codebase and install everything for a developer context. 
-
+Guidelines for new users still need to be developed.
+For new users, we recommend following the instructions in the [Tutorials](#tutorials) section of this README.
+Installation instructions are intended for users already familiar with the project.
 
 # Installation
 
-First clone the repository using the `develop` branch:
+## Repository Layout
+
+This is a so-called monorepo. `PyEarthTools` comprises multiple, modular packages within a shared namespace that inter-operate in order to provide the overall functionality of the framework. It is not necessary to install all of them, and it is envisioned that many users are likely to want only some parts of the framework. As such, each sub-package is a fully independent Python package, with its own requirements and its own installation process. Each of these sub-packages lies in the [`packages`](packages/) subdirectory.
+
+## User installation
+
+Each of PyEarthTools package can be installed separately using `pip`, directly from GitHub.
+For example, to install the `pyearthtools-utils` package, use:
 
 ```
-git clone git@github.com:ACCESS-Community-Hub/PyEarthTools.git
+pip install git+https://github.com/ACCESS-Community-Hub/PyEarthTools.git#subdirectory=packages/utils
+```
+
+Other available packages are `pyearthtools-data`, `pyearthtools-pipeline` and `pyearthtools-training`, that can be installed as follows:
+
+```
+pip install git+https://github.com/ACCESS-Community-Hub/PyEarthTools.git#subdirectory=packages/data
+pip install git+https://github.com/ACCESS-Community-Hub/PyEarthTools.git#subdirectory=packages/pipeline
+pip install git+https://github.com/ACCESS-Community-Hub/PyEarthTools.git#subdirectory=packages/training
+```
+
+> [!NOTE]
+> When this repository is ready for wider use, the intention is to release `PyEarthTools` on PyPI and conda-forge.
+
+## Developer installation
+
+Developers of `PyEarthTools` will most likely want to check out the entire monorepo and work on changesets which may span sub-packages. Each sub-package is versioned separately, so bugfixes or updates in a single sub-package can be performed independently without requiring a new release of the entire ecosystem. 
+
+First clone this repository:
+
+```
+git clone https://github.com/ACCESS-Community-Hub/PyEarthTools.git
+```
+
+and install all packages in "editable" mode with
+
+```
+cd PyEarthTools
+pip install -r requirements-dev.txt
+```
+
+> [!WARNING]
+> We do recommend using a Python virtual environment or a Conda environment when developing, to isolate this installation from the rest of your system.
+> Examples are provided in the [Tutorials](#tutorials) section.
+
+
+# Tutorials
+
+First clone the repository:
+
+```
+git clone https://github.com/ACCESS-Community-Hub/PyEarthTools.git
 cd pyearthtools
 ```
 

--- a/packages/tutorial/README.md
+++ b/packages/tutorial/README.md
@@ -1,30 +1,5 @@
 # PyEarthTools tutorials
 
-First clone this repository:
+Tutorial material to get started with `PyEarthTools`.
 
-```
-git clone https://github.com/ACCESS-Community-Hub/PyEarthTools.git
-cd PyEarthTools/packages/tutorial
-```
-
-Then create a Conda environment to install all dependencies:
-
-```
-conda env create -f environment.yml -p ./venv
-```
-
-To run the example [notebooks](nbook/), you can either
-
-- start a JupyterLab instance
-
-```
-conda activate ./venv
-jupyter lab
-```
-
-- or install a Jupyter kernel to use in a pre-existing JupyterLab installation
-
-```
-conda activate ./venv
-python -m ipykernel install --user --name PET-tutorial
-```
+See the main [README](../../README.md#tutorials) for instructions.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 -e packages/utils
 -e packages/data
--e packages/tutorial/
+-e packages/training
 -e packages/pipeline
+-e packages/tutorial


### PR DESCRIPTION
Hi,

This pull request expand the installation instructions, to include

- installation for users (pip install from github, to integrate PyEarthTools as a dependency in other projects)
- installation for developers (clone monorepo and install in edit mode)

Also, I have migrated the tutorial installation instructions in the main page, so that a new user would see them directly, without having to go to another page.

Few things are currently missing for the installation for users instructions:

- there is no dependency resolution, so pip installing pipeline without pip installing data will break, as `pyearthtools-pipeline` will complain that it cannot find `pyearthtools-data` (I am looking for a technical solution, otherwise will add a comment in the docs),
- I have not documented how to request a specific version/tag/branch, maybe I should add this.