### PR TITLE
Update metadata in pyproject.toml files to point to the correct URLs

### DIFF
--- a/packages/data/pyproject.toml
+++ b/packages/data/pyproject.toml
@@ -52,9 +52,9 @@ all = [
 ]
 
 [project.urls]
-homepage = "http://bom.gov.au"
-documentation = "https://git.nci.org.au/bom/dset/pyearthtools-package/documentation"
-repository = "https://git.nci.org.au/bom/dset/pyearthtools-package/data"
+homepage = "https://pyearthtools.readthedocs.io/"
+documentation = "https://pyearthtools.readthedocs.io/"
+repository = "https://github.com/ACCESS-Community-Hub/PyEarthTools"
 
 [project.scripts]
 pyearthtools-data = "pyearthtools.data.commands:entry_point"

--- a/packages/pipeline/pyproject.toml
+++ b/packages/pipeline/pyproject.toml
@@ -44,9 +44,9 @@ all = [
 ]
 
 [project.urls]
-homepage = "https://bom.gov.au"
-documentation = "https://git.nci.org.au/bom/dset/pyearthtools-package/documentation"
-repository = "https://git.nci.org.au/bom/dset/pyearthtools-package/pipeline_v2"
+homepage = "https://pyearthtools.readthedocs.io/"
+documentation = "https://pyearthtools.readthedocs.io/"
+repository = "https://github.com/ACCESS-Community-Hub/PyEarthTools"
 
 [tool.isort]
 profile = "black"

--- a/packages/pyearthtools_main/pyproject.toml
+++ b/packages/pyearthtools_main/pyproject.toml
@@ -37,9 +37,9 @@ models = [
 test = ["pytest"]
 
 [project.urls]
-homepage = "http://bom.gov.au"
-documentation = "https://git.nci.org.au/bom/dset/pyearthtools-package/documentation"
-repository = "https://git.nci.org.au/bom/dset/pyearthtools-package/"
+homepage = "https://pyearthtools.readthedocs.io/"
+documentation = "https://pyearthtools.readthedocs.io/"
+repository = "https://github.com/ACCESS-Community-Hub/PyEarthTools"
 
 [tool.isort]
 profile = "black"

--- a/packages/training/pyproject.toml
+++ b/packages/training/pyproject.toml
@@ -59,11 +59,10 @@ all = [
   "pyearthtools-training[onnx_gpu]",
 ]
 
-
 [project.urls]
-homepage = "https://bom.gov.au"
-documentation = "https://git.nci.org.au/bom/dset/pyearthtools-package/documentation"
-repository = "https://git.nci.org.au/bom/dset/pyearthtools-package/training"
+homepage = "https://pyearthtools.readthedocs.io/"
+documentation = "https://pyearthtools.readthedocs.io/"
+repository = "https://github.com/ACCESS-Community-Hub/PyEarthTools"
 
 [project.scripts]
 pyearthtools-training = "pyearthtools.training.commands:entry_point"

--- a/packages/tutorial/pyproject.toml
+++ b/packages/tutorial/pyproject.toml
@@ -35,8 +35,9 @@ dynamic = ["version", "readme"]
 readme = {file = ["README.md"], content-type = "text/markdown"}
 
 [project.urls]
-homepage = "http://bom.gov.au"
-documentation = "https://git.nci.org.au/bom/dset/pyearthtools-package/tutorial"
+homepage = "https://pyearthtools.readthedocs.io/"
+documentation = "https://pyearthtools.readthedocs.io/"
+repository = "https://github.com/ACCESS-Community-Hub/PyEarthTools"
 
 [tool.isort]
 profile = "black"

--- a/packages/utils/pyproject.toml
+++ b/packages/utils/pyproject.toml
@@ -31,9 +31,9 @@ dependencies = [
 dynamic = ["version", "readme"]
 
 [project.urls]
-homepage = "https://bom.gov.au"
-documentation = "https://git.nci.org.au/bom/dset/pyearthtools-package/documentation"
-repository = "https://git.nci.org.au/bom/dset/pyearthtools-package/utils"
+homepage = "https://pyearthtools.readthedocs.io/"
+documentation = "https://pyearthtools.readthedocs.io/"
+repository = "https://github.com/ACCESS-Community-Hub/PyEarthTools"
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
- Set homepage and documentation to https://pyearthtools.readthedocs.io/
- Set repository to https://github.com/ACCESS-Community-Hub/PyEarthTools

Closes #14