### PR TITLE
Path iterator bugfix

### DIFF
--- a/packages/data/src/pyearthtools/data/operations/index_routines.py
+++ b/packages/data/src/pyearthtools/data/operations/index_routines.py
@@ -112,6 +112,7 @@ def series(
         end = end + interval
 
     function = _mf_series
+
     if use_single:
         function = _get_series
     # else:
@@ -216,7 +217,17 @@ def series(
             )
 
         # subset_ds = subset_ds.where(subset_ds.time < end.datetime64(), drop=True)
-        subset_ds = subset_ds.sel(**{time_dim: slice(None, end.datetime64())})
+
+        try:
+            subset_ds = subset_ds.sel(**{time_dim: slice(None, end.datetime64())})
+        except TypeError:
+            # We may be entering a non-gregorian calendar zone supported by cftime only
+            # TODO: see if we can recognise and handle this a bit more gracefull, such as in the __lt__ method of petdatetime
+            calendar = subset_ds.time[0].item().calendar
+            end = end.to_cftime(calendar=calendar)
+            subset_ds = subset_ds.sel(**{time_dim: slice(None, end)})
+            
+                                    
 
         if not len(subset_ds[time_dim]) == 0:
             data = subset_ds
@@ -277,6 +288,7 @@ def _mf_series(
 
             paths = get_path(files)
             dataset_paths.extend(paths if isinstance(paths, list) else [paths])
+            dataset_paths = list(set(dataset_paths))
 
         except (DataNotFoundError, InvalidIndexError, InvalidDataError) as e:
             timesteps.remove(query_time)
@@ -316,10 +328,23 @@ def _mf_series(
     open_kwargs.update(pyearthtools.utils.config.get("data.open.xarray_mf"))
     open_kwargs.update(kwargs)
 
-    full_ds = xr.open_mfdataset(
-        list(set(dataset_paths)),
-        **open_kwargs,
-    )
+    try:
+        full_ds = xr.open_mfdataset(
+            list(set(dataset_paths)),
+            **open_kwargs,
+        )
+    except NotImplementedError:
+        # Work around a bug/gap in xarray for loading NetCDF4 files and autochunking
+
+        open_kwargs.pop('chunks')
+
+        full_ds = xr.open_mfdataset(
+            list(set(dataset_paths)),
+            **open_kwargs,
+        )
+                
+
+
     # full_ds = xr.merge(
     #     [
     #         xr.open_mfdataset( # moving out of preprocess due to issues with transforms needing all data

--- a/packages/data/src/pyearthtools/data/operations/index_routines.py
+++ b/packages/data/src/pyearthtools/data/operations/index_routines.py
@@ -266,7 +266,9 @@ def _mf_series(
                     return paths
                 elif isinstance(file, (list, tuple)):
                     for f in file:
-                        if isinstance(f, Iterable):
+                        if isinstance(f, str):
+                            paths.append(f)
+                        elif isinstance(f, Iterable):
                             paths.extend(get_path(f))
                         else:
                             paths.append(f)

--- a/packages/data/src/pyearthtools/data/time.py
+++ b/packages/data/src/pyearthtools/data/time.py
@@ -267,6 +267,7 @@ class pyearthtoolsDatetime:
             resolution (str | TimeResolution | None, optional):
                 Override for resolution specification. Defaults to None.
         """
+
         _pandas_timestep = None
         if isinstance(time, str) and time == "today":
             time = str(datetime.datetime.today().strftime("%Y-%m-%d"))
@@ -324,6 +325,22 @@ class pyearthtoolsDatetime:
         """
         return datetime.datetime.fromisoformat(self.qualified.isoformat())
 
+    def to_cftime(self, calendar='noleap'):
+        '''
+        This method will throw an exception if cftime is not installed.
+        '''
+        import cftime
+        si = self.datetime
+        converted = cftime.datetime(si.year, si.month, si.day, si.hour, si.minute, si.second, si.microsecond, calendar=calendar)
+        return converted
+
+
+
+
+
+
+
+    
     @staticmethod
     def is_time(time_to_parse: Any) -> bool:
         """

--- a/packages/data/src/pyearthtools/data/transforms/transform.py
+++ b/packages/data/src/pyearthtools/data/transforms/transform.py
@@ -238,6 +238,11 @@ class TransformCollection(initialisation.InitialisationRecordingMixin):
         return self.__call__(dataset)
 
     def __call__(self, dataset: XR_TYPES | tuple[XR_TYPES] | list[XR_TYPES] | dict[str, XR_TYPES]) -> XR_TYPES | Any:
+
+        # Do not try to transform empty datasets  
+        if not dataset:
+            return dataset
+
         for transform in self._transforms:
             dataset = transform(dataset)
         return dataset


### PR DESCRIPTION
Fixes two problems encountered on the same dataset.
 (1) The code which works out what files are relevant would sometimes split strings into characters by mistake
 (2) The code which would join two datasets together and re-aggregate them by time would fail when cftime classes were used and the calendar was not a standard gregorian calendar

This includes a reasonable fix for (1) and handles the specific error associated with (2) although perhaps something more elegant can be found in future.