### PR TITLE
Increased unit test coverage for reorder.py to 100%

### DIFF
--- a/packages/utils/tests/pyearthtools/utils/data/tesselator/test_reorder.py
+++ b/packages/utils/tests/pyearthtools/utils/data/tesselator/test_reorder.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 from pyearthtools.utils.data.tesselator._patching.reorder import setup_formats, reorder, move_to_end
 
+# Test the setup_formats function.
 def test_setup_formats():
     # Test with one fully defined format and one partially defined format.
     assert setup_formats('RPTCHW', 'RP...HW') == ('RPTCHW', 'RPTCHW')
@@ -14,12 +15,46 @@ def test_setup_formats():
 
 
     # Test with different combinations of characters in the formats.
-    assert setup_formats('RP...HW', 'RPTCHW') == ('RPXYHW', 'RPXYHW')
+    assert setup_formats('RP...HW', 'RPXYHW') == ('RPXYHW', 'RPXYHW')
 
 def test_setup_formats_value_error():
     with pytest.raises(ValueError):
         # Test with both formats partially defined (should raise ValueError).
         setup_formats('RP...HW', 'RP...HW')
+
+
+# Test the reorder function.
+def test_reorder_same_format():
+    data = np.zeros((3, 4, 5))
+    result = reorder(data, 'TAC', 'TAC')
+    np.testing.assert_array_equal(result, data)
+
+    # Test with same longer formats.
+    data = np.zeros((3, 4, 5, 6))
+    result = reorder(data, 'CTHW', 'CTHW')
+    np.testing.assert_array_equal(result, data)
+
+def test_reorder_different_formats():
+    data = np.zeros((3, 4, 5))
+    result = reorder(data, 'TAC', 'CAT')
+    assert result.shape == (5, 4, 3)
+
+    result = reorder(data, 'TAC', 'CTA')
+    assert result.shape == (5, 3, 4)
+
+    # Test with different longer formats.
+    data = np.zeros((3, 4, 5, 6))
+    result = reorder(data, 'CTHW', 'WHTC')
+    assert result.shape == (6, 5, 4, 3)
+
+    result = reorder(data, 'CTHW', 'WCTH')
+    assert result.shape == (6, 3, 4, 5)
+
+def test_reorder_invalid_format():
+    data = np.zeros((3, 4, 5))
+    with pytest.raises(ValueError):
+        reorder(data, 'TAC', 'CT')
+
 
 if __name__ == "__main__":
     pytest.main()

--- a/packages/utils/tests/pyearthtools/utils/data/tesselator/test_reorder.py
+++ b/packages/utils/tests/pyearthtools/utils/data/tesselator/test_reorder.py
@@ -1,0 +1,25 @@
+import numpy as np
+import pytest
+from pyearthtools.utils.data.tesselator._patching.reorder import setup_formats, reorder, move_to_end
+
+def test_setup_formats():
+    # Test with one fully defined format and one partially defined format.
+    assert setup_formats('RPTCHW', 'RP...HW') == ('RPTCHW', 'RPTCHW')
+    assert setup_formats('TCRPHW', 'RP...HW') == ('TCRPHW', 'RPTCHW')
+    assert setup_formats('RP...HW', 'TCRPHW') == ('RPTCHW', 'TCRPHW')
+
+    # Test with both formats fully defined.
+    assert setup_formats('RPTCHW', 'RPTCHW') == ('RPTCHW', 'RPTCHW')
+    assert setup_formats('TCRPHW', 'RPTCHW') == ('TCRPHW', 'RPTCHW')
+
+
+    # Test with different combinations of characters in the formats.
+    assert setup_formats('RP...HW', 'RPTCHW') == ('RPXYHW', 'RPXYHW')
+
+def test_setup_formats_value_error():
+    with pytest.raises(ValueError):
+        # Test with both formats partially defined (should raise ValueError).
+        setup_formats('RP...HW', 'RP...HW')
+
+if __name__ == "__main__":
+    pytest.main()

--- a/packages/utils/tests/pyearthtools/utils/data/tesselator/test_reorder.py
+++ b/packages/utils/tests/pyearthtools/utils/data/tesselator/test_reorder.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 from pyearthtools.utils.data.tesselator._patching.reorder import setup_formats, reorder, move_to_end
 
-# Test the setup_formats function.
+# Test setup_formats function.
 def test_setup_formats():
     # Test with one fully defined format and one partially defined format.
     assert setup_formats('RPTCHW', 'RP...HW') == ('RPTCHW', 'RPTCHW')
@@ -13,7 +13,6 @@ def test_setup_formats():
     assert setup_formats('RPTCHW', 'RPTCHW') == ('RPTCHW', 'RPTCHW')
     assert setup_formats('TCRPHW', 'RPTCHW') == ('TCRPHW', 'RPTCHW')
 
-
     # Test with different combinations of characters in the formats.
     assert setup_formats('RP...HW', 'RPXYHW') == ('RPXYHW', 'RPXYHW')
 
@@ -23,14 +22,13 @@ def test_setup_formats_value_error():
         setup_formats('RP...HW', 'RP...HW')
 
 
-# Test the reorder function.
+# Test reorder function.
 def test_reorder_same_format():
     data = np.zeros((3, 4, 5))
     result = reorder(data, 'TAC', 'TAC')
     np.testing.assert_array_equal(result, data)
 
-    # Test with same longer formats.
-    data = np.zeros((3, 4, 5, 6))
+    data = np.zeros((3, 4, 5, 6)) # Test with same longer formats.
     result = reorder(data, 'CTHW', 'CTHW')
     np.testing.assert_array_equal(result, data)
 
@@ -56,5 +54,30 @@ def test_reorder_invalid_format():
         reorder(data, 'TAC', 'CT')
 
 
-if __name__ == "__main__":
+# Test move_to_end function.
+def test_move_to_end_single_axis():
+    data = np.zeros((3, 4, 5))
+    new_format, reordered_data = move_to_end(data, 'TAC', 'T')
+    assert new_format == 'ACT'
+    assert reordered_data.shape == (4, 5, 3)
+
+def test_move_to_end_multiple_axes():
+    data = np.zeros((3, 4, 5))
+    new_format, reordered_data = move_to_end(data, 'TAC', 'TA')
+    assert new_format == 'CTA'
+    assert reordered_data.shape == (5, 3, 4)
+
+def test_move_to_end_all_axes():
+    # Test with all axes, i.e. moving all the data.
+    data = np.zeros((3, 4, 5))
+    new_format, reordered_data = move_to_end(data, 'TAC', 'AT')
+    assert new_format == 'CAT'
+    assert reordered_data.shape == (5, 4, 3)
+
+def test_move_to_end_invalid_axis():
+    data = np.zeros((3, 4, 5))
+    with pytest.raises(KeyError):
+        move_to_end(data, 'TAC', 'X')
+
+if __name__ == '__main__':
     pytest.main()

--- a/packages/utils/tests/pyearthtools/utils/data/tesselator/test_reorder.py
+++ b/packages/utils/tests/pyearthtools/utils/data/tesselator/test_reorder.py
@@ -78,6 +78,3 @@ def test_move_to_end_invalid_axis():
     data = np.zeros((3, 4, 5))
     with pytest.raises(KeyError):
         move_to_end(data, 'TAC', 'X')
-
-if __name__ == '__main__':
-    pytest.main()


### PR DESCRIPTION
I've added unit tests that explicitly run all lines in reorder.py (as opposed to being run as part of another test).