### PR TITLE
Correct issue in pyearthtoolsDatetime comparisons and rename class

### DIFF
--- a/packages/data/src/pyearthtools/data/__init__.py
+++ b/packages/data/src/pyearthtools/data/__init__.py
@@ -81,8 +81,8 @@ __version__ = "0.1.0"
 from pyearthtools.data import logger
 from pyearthtools.data import config
 
-from pyearthtools.data.time import pyearthtoolsDatetime, TimeResolution, TimeDelta, TimeRange
-from pyearthtools.data.time import pyearthtoolsDatetime as datetime
+from pyearthtools.data.time import Petdt, TimeResolution, TimeDelta, TimeRange
+from pyearthtools.data.time import Petdt as datetime
 
 from pyearthtools.data.exceptions import DataNotFoundError, InvalidIndexError
 from pyearthtools.data.warnings import (

--- a/packages/data/src/pyearthtools/data/archive/zarr.py
+++ b/packages/data/src/pyearthtools/data/archive/zarr.py
@@ -30,7 +30,7 @@ import dask
 import logging
 
 import pyearthtools.data
-from pyearthtools.data.time import pyearthtoolsDatetime
+from pyearthtools.data.time import Petdt
 from pyearthtools.data.transforms import Transform, TransformCollection
 from pyearthtools.data.indexes.indexes import DataFileSystemIndex, TimeIndex
 
@@ -323,7 +323,7 @@ class ZarrTimeIndex(ZarrIndex, TimeIndex):
 
     def retrieve(
         self,
-        querytime: str | pyearthtoolsDatetime | None = None,
+        querytime: str | Petdt | None = None,
         *args,
         transforms: Transform | TransformCollection | None = None,
         **kwargs,
@@ -335,7 +335,7 @@ class ZarrTimeIndex(ZarrIndex, TimeIndex):
         if querytime is not None:
 
             def to_np(x):
-                return pyearthtoolsDatetime(x).datetime64()
+                return Petdt(x).datetime64()
 
             base_data = base_data.sel(
                 {
@@ -363,5 +363,5 @@ class ZarrTimeIndex(ZarrIndex, TimeIndex):
         if querytime is not None:
             time_dim = identify_time_dimension(zarr)
 
-            exists_bool = exists_bool and pyearthtoolsDatetime(querytime).datetime64() in zarr[time_dim]
+            exists_bool = exists_bool and Petdt(querytime).datetime64() in zarr[time_dim]
         return exists_bool

--- a/packages/data/src/pyearthtools/data/derived/derived.py
+++ b/packages/data/src/pyearthtools/data/derived/derived.py
@@ -26,7 +26,7 @@ from abc import abstractmethod, ABCMeta
 import xarray as xr
 
 
-from pyearthtools.data.time import pyearthtoolsDatetime, TimeDelta, TimeRange
+from pyearthtools.data.time import Petdt, TimeDelta, TimeRange
 from pyearthtools.data.indexes import DataIndex, TimeDataIndex, AdvancedTimeDataIndex
 
 
@@ -53,7 +53,7 @@ class DerivedValue(DataIndex, metaclass=ABCMeta):
         """Override for get to use `derive`."""
         args = list(args)
         for i, arg in enumerate(args):
-            if isinstance(arg, pyearthtoolsDatetime):
+            if isinstance(arg, Petdt):
                 args[i] = arg.datetime64()
         return self.derive(*args, **kwargs)
 

--- a/packages/data/src/pyearthtools/data/download/arco/ERA5.py
+++ b/packages/data/src/pyearthtools/data/download/arco/ERA5.py
@@ -20,7 +20,7 @@ import xarray as xr
 from os import PathLike
 
 import pyearthtools.data
-from pyearthtools.data.time import pyearthtoolsDatetime
+from pyearthtools.data.time import Petdt
 
 from pyearthtools.data.indexes import AdvancedTimeDataIndex, decorators, CachingIndex
 from pyearthtools.data.transforms.transform import Transform, TransformCollection
@@ -147,7 +147,7 @@ class ARCOERA5(AdvancedTimeDataIndex):
 
     def get(self, time: str):
         """Get timestep from dataset"""
-        return self._ds.sel(time=pyearthtoolsDatetime(time).datetime64())
+        return self._ds.sel(time=Petdt(time).datetime64())
 
     @classmethod
     def sample(cls):

--- a/packages/data/src/pyearthtools/data/download/cds/ERA5.py
+++ b/packages/data/src/pyearthtools/data/download/cds/ERA5.py
@@ -24,7 +24,7 @@ import warnings
 
 
 import pyearthtools.data
-from pyearthtools.data import pyearthtoolsDatetime
+from pyearthtools.data import Petdt
 from pyearthtools.data.warnings import pyearthtoolsDataWarning
 
 from pyearthtools.data.indexes import decorators
@@ -192,19 +192,19 @@ class ERA5(root_cds):
         self._variables = variables
         self._product = product
 
-    def _get_from_cds(self, querytime: pyearthtoolsDatetime | str) -> tuple[str, dict] | list[tuple[str, dict]]:
+    def _get_from_cds(self, querytime: Petdt | str) -> tuple[str, dict] | list[tuple[str, dict]]:
         """
         Format cds query for data as needed
 
         Args:
-            querytime (pyearthtoolsDatetime | str):
+            querytime (Petdt | str):
                 Datetime to get data for
 
         Returns:
             (tuple[str, dict] | list[tuple[str, dict]]):
                 Tuple for request or list of tupled requests
         """
-        querytime = pyearthtoolsDatetime(querytime).at_resolution("hour")
+        querytime = Petdt(querytime).at_resolution("hour")
 
         base_dict = {
             "product_type": as_list(self._product),

--- a/packages/data/src/pyearthtools/data/download/cds/cds.py
+++ b/packages/data/src/pyearthtools/data/download/cds/cds.py
@@ -27,7 +27,7 @@ import warnings
 
 import urllib3
 
-from pyearthtools.data import DataNotFoundError, pyearthtoolsDatetime
+from pyearthtools.data import DataNotFoundError, Petdt
 from pyearthtools.data.download import DownloadIndex
 from pyearthtools.data.indexes import utilities
 from pyearthtools.data.patterns import TemporalExpandedDateVariable, PatternIndex
@@ -251,8 +251,8 @@ class cds(root_cds):
 
         super().__init__(**kwargs)  # type: ignore
 
-    def _get_from_cds(self, querytime: pyearthtoolsDatetime | str):
-        querytime = pyearthtoolsDatetime(querytime)
+    def _get_from_cds(self, querytime: Petdt | str):
+        querytime = Petdt(querytime)
 
         base_dict = {
             "format": "netcdf",

--- a/packages/data/src/pyearthtools/data/download/ecmwf_opendata/opendata.py
+++ b/packages/data/src/pyearthtools/data/download/ecmwf_opendata/opendata.py
@@ -44,7 +44,7 @@ VARIABLES = [*opendata_variables.single, *opendata_variables.pressure, "all"]
 RENAME_DICT = {"t2m": "2t", "u10": "10u", "v10": "10v"}
 
 
-def rounder(time: pyearthtools.data.pyearthtoolsDatetime, round_value: int = 6) -> int:
+def rounder(time: pyearthtools.data.Petdt, round_value: int = 6) -> int:
     return (time.hour // round_value) * round_value
 
 
@@ -195,7 +195,7 @@ class OpenData(DownloadIndex):
         """Get the latest data from `ecwmf-opendata`"""
         return self(self._get_latest())
 
-    def download(self, querytime: str | pyearthtools.data.pyearthtoolsDatetime) -> xr.Dataset:
+    def download(self, querytime: str | pyearthtools.data.Petdt) -> xr.Dataset:
         """Download data from `ecwmf-opendata`"""
         if self._client is None:
             raise ImportError(f"`ecwmwf.opendata` was not imported, cannot download new data.")
@@ -203,8 +203,8 @@ class OpenData(DownloadIndex):
         if querytime == "l1atest":
             querytime = self._get_latest()
 
-        date = pyearthtools.data.pyearthtoolsDatetime(querytime).at_resolution("day")
-        time = rounder(pyearthtools.data.pyearthtoolsDatetime(querytime))
+        date = pyearthtools.data.Petdt(querytime).at_resolution("day")
+        time = rounder(pyearthtools.data.Petdt(querytime))
 
         request = dict(self._request_base)
         path = self.get_tempdir()

--- a/packages/data/src/pyearthtools/data/indexes/combine.py
+++ b/packages/data/src/pyearthtools/data/indexes/combine.py
@@ -19,7 +19,7 @@ import xarray as xr
 
 
 from pyearthtools.data.indexes import Index, AdvancedTimeDataIndex
-from pyearthtools.data import pyearthtoolsDatetime
+from pyearthtools.data import Petdt
 from pyearthtools.data.operations import SpatialInterpolation, TemporalInterpolation
 from pyearthtools.data.transforms.transform import Transform, TransformCollection
 
@@ -40,7 +40,7 @@ class InterpolationIndex(AdvancedTimeDataIndex):
 
     def retrieve(
         self,
-        querytime: str | pyearthtoolsDatetime,
+        querytime: str | Petdt,
         *,
         aggregation: str = None,
         select: bool = True,

--- a/packages/data/src/pyearthtools/data/indexes/fake.py
+++ b/packages/data/src/pyearthtools/data/indexes/fake.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import xarray as xr
 import numpy as np
 
-from pyearthtools.data.time import pyearthtoolsDatetime
+from pyearthtools.data.time import Petdt
 from pyearthtools.data.indexes.indexes import AdvancedTimeDataIndex
 
 from pyearthtools.data.indexes.decorators import variable_modifications
@@ -75,8 +75,8 @@ class FakeIndex(AdvancedTimeDataIndex):
 
         self._data_function = self.rng.random if random else np.ones
 
-    def get(self, time: pyearthtoolsDatetime | str) -> xr.Dataset:
-        time = pyearthtoolsDatetime(time)
+    def get(self, time: Petdt | str) -> xr.Dataset:
+        time = Petdt(time)
 
         def make_data(name) -> xr.Dataset:
             data = xr.DataArray(

--- a/packages/data/src/pyearthtools/data/indexes/indexes.py
+++ b/packages/data/src/pyearthtools/data/indexes/indexes.py
@@ -42,7 +42,7 @@ import xarray as xr
 import pyearthtools.data
 import pyearthtools.utils
 
-from pyearthtools.data.time import pyearthtoolsDatetime, TimeDelta, TimeRange
+from pyearthtools.data.time import Petdt, TimeDelta, TimeRange
 
 from pyearthtools.data.transforms.transform import (
     Transform,
@@ -325,13 +325,13 @@ class DataIndex(Index):
 
 class SingleTimeIndex(Index):
     """
-    Introduce single time based Indexing with [pyearthtoolsDatetime][pyearthtools.data.time.pyearthtoolsDatetime].
+    Introduce single time based Indexing with [Petdt][pyearthtools.data.time.Petdt].
 
     While [Index][pyearthtools.data.indexes.indexes.Index] assumes nothing about the selection arguments,
-    this will attempt to convert them to a [pyearthtoolsDatetime][pyearthtools.data.time.pyearthtoolsDatetime], and select that time
+    this will attempt to convert them to a [Petdt][pyearthtools.data.time.Petdt], and select that time
     from the data.
 
-    [pyearthtoolsDatetime][pyearthtools.data.time.pyearthtoolsDatetime] keeps a record of the resolution of the given date string,
+    [Petdt][pyearthtools.data.time.Petdt] keeps a record of the resolution of the given date string,
     which allows for more informative warnings.
 
     """
@@ -429,7 +429,7 @@ class SingleTimeIndex(Index):
 
     def retrieve(
         self,
-        querytime: str | pyearthtoolsDatetime,
+        querytime: str | Petdt,
         *args,
         select: bool = False,
         round: bool | None = None,
@@ -441,7 +441,7 @@ class SingleTimeIndex(Index):
         While [Index][pyearthtools.data.indexes.Index] assumes nothing, this will attempt to select time.
 
         Args:
-            querytime (str | datetime.datetime | pyearthtoolsDatetime):
+            querytime (str | datetime.datetime | Petdt):
                 Timestep to retrieve data at
             select (bool, optional):
                 Select `querytime` in dataset. Defaults to False.
@@ -453,7 +453,7 @@ class SingleTimeIndex(Index):
             (Any):
                 Loaded data, with time selected
         """
-        querytime = pyearthtoolsDatetime(querytime)
+        querytime = Petdt(querytime)
         if self.data_resolution and querytime.resolution < self.data_resolution:
             warnings.warn(
                 f"Data requested at a lower resolution than data exists at. {querytime.resolution} < {self.data_resolution}. \n"
@@ -477,7 +477,7 @@ class SingleTimeIndex(Index):
         if select and time_dim in data:
             try:
                 data = data.sel(
-                    **{time_dim: str(pyearthtoolsDatetime(querytime))},
+                    **{time_dim: str(Petdt(querytime))},
                     method="nearest" if round else None,
                 )
             except KeyError:
@@ -494,7 +494,7 @@ class SingleTimeIndex(Index):
 
 class TimeIndex(SingleTimeIndex):
     """
-    Introduce general time based Indexing with [pyearthtoolsDatetime][pyearthtools.data.time.pyearthtoolsDatetime].
+    Introduce general time based Indexing with [Petdt][pyearthtools.data.time.Petdt].
 
     Allow for multiple time retrievals.
     """
@@ -502,8 +502,8 @@ class TimeIndex(SingleTimeIndex):
     @functools.wraps(index_routines.series)
     def series(
         self,
-        start: str | pyearthtoolsDatetime,
-        end: str | pyearthtoolsDatetime,
+        start: str | Petdt,
+        end: str | Petdt,
         interval: TimeDelta | tuple[int | float, str] | int | None = None,
         *,
         transforms: TransformCollection | Transform = TransformCollection(),
@@ -513,9 +513,9 @@ class TimeIndex(SingleTimeIndex):
         API Function of [series][pyearthtools.data.index_operations.index_routines.series] for each AdvancedTimeIndex
 
         Args:
-            start (str | pyearthtoolsDatetime):
+            start (str | Petdt):
                 Start time for series
-            end (str | pyearthtoolsDatetime):
+            end (str | Petdt):
                 End time for series
             interval (TimeDelta, optional):
                 Interval to retrieve data at. Defaults to initialise resolution.
@@ -543,8 +543,8 @@ class TimeIndex(SingleTimeIndex):
     @functools.wraps(index_routines.safe_series)
     def safe_series(
         self,
-        start: str | pyearthtoolsDatetime,
-        end: str | pyearthtoolsDatetime,
+        start: str | Petdt,
+        end: str | Petdt,
         interval: TimeDelta | tuple[int | float, str] | None = None,
         *,
         transforms: TransformCollection | Transform = TransformCollection(),
@@ -556,9 +556,9 @@ class TimeIndex(SingleTimeIndex):
         Provides a safer way into get a series of data.
 
         Args:
-            start (str | pyearthtoolsDatetime):
+            start (str | Petdt):
                 Start time for series
-            end (str | pyearthtoolsDatetime):
+            end (str | Petdt):
                 End time for series
             interval (tuple[int, str], optional):
                 Interval to retrieve data at. Defaults to initialised resolution .
@@ -586,8 +586,8 @@ class TimeIndex(SingleTimeIndex):
     @functools.wraps(index_operations.aggregation)
     def aggregation(
         self,
-        start: str | pyearthtoolsDatetime,
-        end: str | pyearthtoolsDatetime,
+        start: str | Petdt,
+        end: str | Petdt,
         interval: TimeDelta | tuple[int | float, str] | None = None,
         *,
         transforms: TransformCollection | Transform = TransformCollection(),
@@ -597,9 +597,9 @@ class TimeIndex(SingleTimeIndex):
         API Function of [aggregation][pyearthtools.data.index_operations.index_operations.aggregation] for each AdvancedTimeIndex
 
         Args:
-            start (str | pyearthtoolsDatetime):
+            start (str | Petdt):
                 Start time for series
-            end (str | pyearthtoolsDatetime):
+            end (str | Petdt):
                 End time for series
             interval (tuple[int, str], optional):
                 Interval to retrieve data at. Defaults to initialise resolution .
@@ -612,7 +612,7 @@ class TimeIndex(SingleTimeIndex):
         """
         interval = self._get_interval(interval)
         if self.data_resolution:
-            start = pyearthtoolsDatetime(start).at_resolution(self.data_resolution)
+            start = Petdt(start).at_resolution(self.data_resolution)
         # transforms = self.base_transforms + transforms
 
         return index_operations.aggregation(self, start, end, interval, transforms=transforms, **kwargs)
@@ -620,8 +620,8 @@ class TimeIndex(SingleTimeIndex):
     @functools.wraps(index_operations.find_range)
     def range(
         self,
-        start: str | pyearthtoolsDatetime,
-        end: str | pyearthtoolsDatetime,
+        start: str | Petdt,
+        end: str | Petdt,
         interval: TimeDelta | tuple[int, str] | None = None,
         *,
         transforms: TransformCollection | Transform = TransformCollection(),
@@ -631,9 +631,9 @@ class TimeIndex(SingleTimeIndex):
         API Function of [range][pyearthtools.data.index_operations.index_operations.find_range] for each AdvancedTimeIndex
 
         Args:
-            start (str | pyearthtoolsDatetime):
+            start (str | Petdt):
                 Start time for series
-            end (str | pyearthtoolsDatetime):
+            end (str | Petdt):
                 End time for series
             interval (tuple[int, str], optional):
                 Interval to retrieve data at. Defaults to initialise resolution .
@@ -750,7 +750,7 @@ class AdvancedTimeIndex(TimeIndex):
 
     def retrieve(
         self,
-        querytime: str | datetime.datetime | pyearthtoolsDatetime,
+        querytime: str | datetime.datetime | Petdt,
         *,
         aggregation: str | None = None,
         select: bool = True,
@@ -793,7 +793,7 @@ class AdvancedTimeIndex(TimeIndex):
             Extra transforms can be supplied, using `transforms = `
         """
 
-        querytime = pyearthtoolsDatetime(querytime)
+        querytime = Petdt(querytime)
 
         if not hasattr(self, "data_resolution") or not self.data_resolution or use_simple:
             data = super().retrieve(querytime, select=select, **kwargs)
@@ -818,7 +818,7 @@ class AdvancedTimeIndex(TimeIndex):
             start_time = querytime
 
         # Lower Resolution, find via series
-        end_time = pyearthtoolsDatetime(querytime)
+        end_time = Petdt(querytime)
         end_time += 1  # Automatically adds one to the last defined date
 
         if self.data_resolution:
@@ -887,13 +887,13 @@ class AdvancedTimeIndex(TimeIndex):
             time_values = ds[ds_time_dim].values
 
             if not isinstance(time_values, Iterable):
-                time_values = pyearthtoolsDatetime(time_values)
+                time_values = Petdt(time_values)
                 if self.data_resolution:
                     time_values = time_values.at_resolution(self.data_resolution)
                 return self.retrieve(time_values, transforms=transforms, **kwargs)
 
-            start_time = pyearthtoolsDatetime(time_values[0])
-            end_time = pyearthtoolsDatetime(time_values[-1])
+            start_time = Petdt(time_values[0])
+            end_time = Petdt(time_values[-1])
 
             if self.data_resolution:
                 start_time = start_time.at_resolution(self.data_resolution)
@@ -965,7 +965,7 @@ class ArchiveIndex(AdvancedTimeDataIndex, FileSystemIndex):
     @functools.wraps(FileSystemIndex.search)
     def search(self, *args):
         """
-        Attempt to convert first arg to a [pyearthtoolsDatetime][pyearthtools.data.time.pyearthtoolsDatetime],
+        Attempt to convert first arg to a [Petdt][pyearthtools.data.time.Petdt],
         if conversion fails, ignore and continue
 
         Will operate with time resolution behaviour from `AdvancedTimeIndex`.
@@ -973,7 +973,7 @@ class ArchiveIndex(AdvancedTimeDataIndex, FileSystemIndex):
         args = list(args)
         if len(args) > 0:
             try:
-                date = pyearthtoolsDatetime(args[0])
+                date = Petdt(args[0])
                 if date:
                     args[0] = date
 
@@ -1036,13 +1036,13 @@ class ForecastIndex(TimeIndex, DataFileSystemIndex):
     @functools.wraps(FileSystemIndex.search)
     def search(self, *args) -> Path:
         """
-        Attempt to convert first arg to a [pyearthtoolsDatetime][pyearthtools.data.time.pyearthtoolsDatetime],
+        Attempt to convert first arg to a [Petdt][pyearthtools.data.time.Petdt],
         if conversion fails, ignore and continue
         """
         args = list(args)
         if len(args) > 0:
             try:
-                date = pyearthtoolsDatetime(args[0])
+                date = Petdt(args[0])
                 if date:
                     args[0] = date
             except Exception:
@@ -1052,8 +1052,8 @@ class ForecastIndex(TimeIndex, DataFileSystemIndex):
     @functools.wraps(forecast_op.forecast_series)
     def series(
         self,
-        start: str | pyearthtoolsDatetime,
-        end: str | pyearthtoolsDatetime,
+        start: str | Petdt,
+        end: str | Petdt,
         interval: Optional[TimeDelta | tuple[int, str]] = None,
         *args,
         **kwargs,
@@ -1064,18 +1064,18 @@ class ForecastIndex(TimeIndex, DataFileSystemIndex):
 
     def retrieve(
         self,
-        basetime: str | pyearthtoolsDatetime,
+        basetime: str | Petdt,
         *args,
-        querytime: str | pyearthtoolsDatetime | TimeDelta | None = None,
+        querytime: str | Petdt | TimeDelta | None = None,
         **kwargs,
     ) -> Any:
         """
         Retrieve data from a forecast product, allowing seperate specification of basetime and querytime
 
         Args:
-            basetime (str | pyearthtoolsDatetime):
+            basetime (str | Petdt):
                 Basetime to get forecast from
-            querytime (str | pyearthtoolsDatetime | None, optional):
+            querytime (str | Petdt | None, optional):
                 Time to select from forecast. Defaults to None.
 
         Raises:
@@ -1091,7 +1091,7 @@ class ForecastIndex(TimeIndex, DataFileSystemIndex):
 
         if querytime:
             if isinstance(querytime, (tuple, TimeDelta)):
-                querytime = pyearthtoolsDatetime(basetime) + TimeDelta(querytime)
+                querytime = Petdt(basetime) + TimeDelta(querytime)
 
             if isinstance(data, (xr.Dataset, xr.DataArray)) and time_dim in data:
                 data = data.sel(**{time_dim: [str(querytime)]})
@@ -1101,7 +1101,7 @@ class ForecastIndex(TimeIndex, DataFileSystemIndex):
 
     def aggregation(
         self,
-        querytime: str | pyearthtoolsDatetime,
+        querytime: str | Petdt,
         aggregation: str | Callable,
         *,
         preserve_dims: list | None = None,
@@ -1113,7 +1113,7 @@ class ForecastIndex(TimeIndex, DataFileSystemIndex):
         API Function of [aggregation][pyearthtools.data.index_operations.index_operations.aggregation] for each ForecastIndex
 
         Args:
-            querytime (str | pyearthtoolsDatetime):
+            querytime (str | Petdt):
                 Time to get data at
             aggregation (str | Callable):
                 Aggregation method to apply.

--- a/packages/data/src/pyearthtools/data/indexes/indexes.py
+++ b/packages/data/src/pyearthtools/data/indexes/indexes.py
@@ -775,7 +775,8 @@ class AdvancedTimeIndex(TimeIndex):
             aggregation (str, optional):
                 If data becomes a range, can specify an aggregation method. Defaults to None.
             select (bool, optional):
-                Whether to attempt to select the given timestep if date is either fully qualified or data_interval not given. Defaults to True.
+                Whether to attempt to select the given timestep if date is either fully qualified 
+                or data_interval not given. Defaults to True.
             use_simple (bool, optional):
                 Whether to simply use the DataIndex.retrieve instead. Defaults to False.
             kwargs (Any, optional):

--- a/packages/data/src/pyearthtools/data/indexes/indexes.py
+++ b/packages/data/src/pyearthtools/data/indexes/indexes.py
@@ -775,7 +775,7 @@ class AdvancedTimeIndex(TimeIndex):
             aggregation (str, optional):
                 If data becomes a range, can specify an aggregation method. Defaults to None.
             select (bool, optional):
-                Whether to attempt to select the given timestep if date is either fully qualified 
+                Whether to attempt to select the given timestep if date is either fully qualified
                 or data_interval not given. Defaults to True.
             use_simple (bool, optional):
                 Whether to simply use the DataIndex.retrieve instead. Defaults to False.

--- a/packages/data/src/pyearthtools/data/indexes/templates/structured.py
+++ b/packages/data/src/pyearthtools/data/indexes/templates/structured.py
@@ -20,7 +20,7 @@ Template for structured data
 from __future__ import annotations
 from pathlib import Path
 
-from pyearthtools.data import pyearthtoolsDatetime
+from pyearthtools.data import Petdt
 from pyearthtools.data.indexes import ArchiveIndex, decorators
 from pyearthtools.data.indexes.utilities.spellcheck import VARIABLE_DEFAULT, VariableDefault
 from pyearthtools.data.transforms import Transform, TransformCollection
@@ -99,7 +99,7 @@ class Structured(ArchiveIndex):
             **kwargs,
         )
 
-    def _parse_glob(self, time: pyearthtoolsDatetime, variable: str) -> Path:
+    def _parse_glob(self, time: Petdt, variable: str) -> Path:
         """
         Parse glob path with `time` and `variable`.
         """
@@ -124,13 +124,13 @@ class Structured(ArchiveIndex):
 
     def filesystem(
         self,
-        querytime: str | pyearthtoolsDatetime,
+        querytime: str | Petdt,
     ) -> dict[str, Path]:
         """Get filesystem paths"""
         discovered_paths = {}
 
         for variable in self.variables:
-            discovered_paths[variable] = self._parse_glob(pyearthtoolsDatetime(querytime), variable)
+            discovered_paths[variable] = self._parse_glob(Petdt(querytime), variable)
         return discovered_paths
 
 

--- a/packages/data/src/pyearthtools/data/modifications/aggregations.py
+++ b/packages/data/src/pyearthtools/data/modifications/aggregations.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 from typing import Literal
 import xarray as xr
 
-from pyearthtools.data.time import pyearthtoolsDatetime, TimeDelta, TimeResolution, TimeRange
+from pyearthtools.data.time import Petdt, TimeDelta, TimeResolution, TimeRange
 from pyearthtools.data.indexes.utilities.dimensions import identify_time_dimension
 
 from pyearthtools.data.modifications import Modification, register_modification
@@ -74,7 +74,7 @@ class Aggregation(Modification):
 
         Does not perform the aggreagtion tho
         """
-        time = pyearthtoolsDatetime(time)
+        time = Petdt(time)
         period = self._parse_period()
 
         if self._align == "past":
@@ -96,8 +96,8 @@ class Aggregation(Modification):
 
         Does not perform the aggreagtion tho
         """
-        start = pyearthtoolsDatetime(start)
-        end = pyearthtoolsDatetime(end)
+        start = Petdt(start)
+        end = Petdt(end)
 
         period = self._parse_period()
         start_adjusted = start

--- a/packages/data/src/pyearthtools/data/modifications/constants.py
+++ b/packages/data/src/pyearthtools/data/modifications/constants.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 from typing import Optional, Union
 import xarray as xr
 
-from pyearthtools.data.time import pyearthtoolsDatetime, TimeRange
+from pyearthtools.data.time import Petdt, TimeRange
 from pyearthtools.data.indexes.utilities.dimensions import identify_time_dimension
 
 from pyearthtools.data.modifications import Modification, register_modification
@@ -68,7 +68,7 @@ class Constant(Modification):
         self._query = self._query or time
 
         if self._data is None:
-            data = self._data_index(pyearthtoolsDatetime(self._query).at_resolution(self._data_index.data_resolution))
+            data = self._data_index(Petdt(self._query).at_resolution(self._data_index.data_resolution))
             if self._memory:
                 data = data.compute()
 

--- a/packages/data/src/pyearthtools/data/modifications/reductions.py
+++ b/packages/data/src/pyearthtools/data/modifications/reductions.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 from typing import Union
 import xarray as xr
 
-from pyearthtools.data.time import pyearthtoolsDatetime, TimeDelta, TimeResolution
+from pyearthtools.data.time import Petdt, TimeDelta, TimeResolution
 from pyearthtools.data.indexes.utilities.dimensions import identify_time_dimension
 
 from pyearthtools.data.modifications import Modification, register_modification
@@ -46,8 +46,8 @@ class Groupby(Reduction):
         self.time_component = time_component
         self.method = method
 
-    def _reconstruct_time_dim(self, time: Union[str, pyearthtoolsDatetime], new_coord: xr.DataArray):
-        time = pyearthtoolsDatetime(time)
+    def _reconstruct_time_dim(self, time: Union[str, Petdt], new_coord: xr.DataArray):
+        time = Petdt(time)
 
         return list(
             map(
@@ -69,13 +69,13 @@ class Groupby(Reduction):
         )
 
     def single(self, time) -> xr.Dataset:
-        start = str(pyearthtoolsDatetime(time).at_resolution(TimeResolution(self.time_component)))
-        end = str(pyearthtoolsDatetime(time).at_resolution(TimeResolution(self.time_component)) + 1)
+        start = str(Petdt(time).at_resolution(TimeResolution(self.time_component)))
+        end = str(Petdt(time).at_resolution(TimeResolution(self.time_component)) + 1)
         return self._get_data(start, end)
 
     def series(self, start, end, interval) -> xr.Dataset:
-        start = str(pyearthtoolsDatetime(start).at_resolution(TimeResolution(self.time_component)))
-        end = str(pyearthtoolsDatetime(end).at_resolution(TimeResolution(self.time_component)) + 1)
+        start = str(Petdt(start).at_resolution(TimeResolution(self.time_component)))
+        end = str(Petdt(end).at_resolution(TimeResolution(self.time_component)) + 1)
 
         return self._get_data(start, end)
 

--- a/packages/data/src/pyearthtools/data/operations/forecast_op.py
+++ b/packages/data/src/pyearthtools/data/operations/forecast_op.py
@@ -20,7 +20,7 @@ import xarray as xr
 
 
 from pyearthtools.data.exceptions import DataNotFoundError, InvalidIndexError, InvalidDataError
-from pyearthtools.data.time import pyearthtoolsDatetime, TimeDelta, TimeRange
+from pyearthtools.data.time import Petdt, TimeDelta, TimeRange
 from pyearthtools.data.transforms.transform import Transform, TransformCollection
 from pyearthtools.data.warnings import IndexWarning
 
@@ -30,8 +30,8 @@ from pyearthtools.data.operations.utils import identify_time_dimension
 
 def forecast_series(
     DataFunction: "Index",
-    start: str | pyearthtoolsDatetime,
-    end: str | pyearthtoolsDatetime,
+    start: str | Petdt,
+    end: str | Petdt,
     interval: tuple[float, str] | TimeDelta,
     *,
     lead_time: tuple[float, str] | TimeDelta = None,
@@ -67,8 +67,8 @@ def forecast_series(
 
 def forecast_as_basetime(
     DataFunction: "Index",
-    start: str | pyearthtoolsDatetime,
-    end: str | pyearthtoolsDatetime,
+    start: str | Petdt,
+    end: str | Petdt,
     interval: tuple[float, str] | TimeDelta,
     *,
     inclusive: bool = False,
@@ -105,8 +105,8 @@ def forecast_as_basetime(
 
 def forecast_select_time(
     DataFunction: "Index",
-    start: str | pyearthtoolsDatetime,
-    end: str | pyearthtoolsDatetime,
+    start: str | Petdt,
+    end: str | Petdt,
     interval: tuple[float, str] | TimeDelta,
     lead_time: tuple[float, str] | TimeDelta,
     *,
@@ -118,8 +118,8 @@ def forecast_select_time(
     """
     Forecast Series operation selecting a particular lead time
     """
-    start = pyearthtoolsDatetime(start)
-    end = pyearthtoolsDatetime(end)
+    start = Petdt(start)
+    end = Petdt(end)
     interval = TimeDelta(interval)
 
     lead_time = TimeDelta(lead_time)

--- a/packages/data/src/pyearthtools/data/operations/index_operations.py
+++ b/packages/data/src/pyearthtools/data/operations/index_operations.py
@@ -31,7 +31,7 @@ import xarray as xr
 
 import pyearthtools.data
 
-from pyearthtools.data.time import pyearthtoolsDatetime, TimeDelta
+from pyearthtools.data.time import Petdt, TimeDelta
 from pyearthtools.data.exceptions import (
     DataNotFoundError,
     InvalidIndexError,
@@ -79,8 +79,8 @@ def split_ds_gen(dataset: xr.Dataset, divisions: int = 1, dim: str = "time") -> 
 
 def aggregation(
     DataFunction: "TimeIndex",
-    start: str | datetime.datetime | pyearthtoolsDatetime,
-    end: str | datetime.datetime | pyearthtoolsDatetime,
+    start: str | datetime.datetime | Petdt,
+    end: str | datetime.datetime | Petdt,
     interval: tuple[float, str],
     *,
     aggregation: str = "mean",
@@ -102,9 +102,9 @@ def aggregation(
     Args:
         DataFunction (TimeIndex):
             TimeIndex to retrieve Data
-        start (str | datetime.datetime | pyearthtoolsDatetime):
+        start (str | datetime.datetime | Petdt):
             Start Date
-        end (str | datetime.datetime | pyearthtoolsDatetime):
+        end (str | datetime.datetime | Petdt):
             End Date
         interval (tuple[float, str]):
             Interval between samples. Use pandas.to_timedelta notation, (10, 'minute')
@@ -131,8 +131,8 @@ def aggregation(
     # print("Finding Series ...")
     aggregation_func = pyearthtools.data.transforms.aggregation.over(method=aggregation, dimension=aggregation_dim)
 
-    start = pyearthtoolsDatetime(start)
-    end = pyearthtoolsDatetime(end)
+    start = Petdt(start)
+    end = Petdt(end)
     interval = TimeDelta(interval)
     steps = (end - start) // interval
 
@@ -225,8 +225,8 @@ MAX_VALUE = 1e-10
 
 def find_range(
     DataFunction: "TimeIndex",
-    start: str | pyearthtoolsDatetime,
-    end: str | pyearthtoolsDatetime,
+    start: str | Petdt,
+    end: str | Petdt,
     interval: tuple[float, str] | TimeDelta,
     *,
     skip_invalid: bool = True,
@@ -240,9 +240,9 @@ def find_range(
     Args:
         DataFunction (TimeIndex):
             TimeIndex to retrieve Data
-        start (str | pyearthtoolsDatetime):
+        start (str | Petdt):
             Start Date
-        end (str | pyearthtoolsDatetime):
+        end (str | Petdt):
             End Date
         interval (tuple[float, str]):
             Interval between samples. Use pandas.to_timedelta notation, (10, 'minute')

--- a/packages/data/src/pyearthtools/data/operations/index_routines.py
+++ b/packages/data/src/pyearthtools/data/operations/index_routines.py
@@ -31,7 +31,7 @@ import pyearthtools.data
 import pyearthtools.utils
 
 from pyearthtools.data.exceptions import DataNotFoundError, InvalidIndexError, InvalidDataError
-from pyearthtools.data.time import pyearthtoolsDatetime, TimeDelta, time_delta_resolution, TimeRange
+from pyearthtools.data.time import Petdt, TimeDelta, time_delta_resolution, TimeRange
 from pyearthtools.data.transforms.transform import Transform, TransformCollection
 from pyearthtools.data.warnings import IndexWarning
 from pyearthtools.data.operations.utils import identify_time_dimension
@@ -42,8 +42,8 @@ LOG = logging.getLogger("pyearthtools.data")
 
 def series(
     DataFunction: "AdvancedTimeIndex",
-    start: str | pyearthtoolsDatetime,
-    end: str | pyearthtoolsDatetime,
+    start: str | Petdt,
+    end: str | Petdt,
     interval: tuple[float, str] | TimeDelta,
     *,
     inclusive: bool = False,
@@ -62,9 +62,9 @@ def series(
     Args:
         DataFunction (AdvancedTimeIndex):
             Data function, must be AdvancedTimeIndex or child
-        start (str | datetime.datetime | pyearthtoolsDatetime):
+        start (str | datetime.datetime | Petdt):
             Timestep to begin series at
-        end (str | datetime.datetime | pyearthtoolsDatetime):
+        end (str | datetime.datetime | Petdt):
             Timestep to end series at
         interval (tuple[float, str]):
             Time interval between samples. Use pandas.to_timedelta notation, (10, 'minute')
@@ -98,8 +98,8 @@ def series(
     #     use_single = True
 
     interval = TimeDelta(interval)
-    start = pyearthtoolsDatetime(start)
-    end = pyearthtoolsDatetime(end)
+    start = Petdt(start)
+    end = Petdt(end)
 
     start = start.at_resolution(max(interval.resolution, start.resolution))
     end = end.at_resolution(max(end.resolution, start.resolution))
@@ -241,8 +241,8 @@ def series(
 @functools.wraps(series)
 def _mf_series(
     DataFunction: "AdvancedTimeIndex",
-    start: pyearthtoolsDatetime,
-    end: pyearthtoolsDatetime,
+    start: Petdt,
+    end: Petdt,
     interval: TimeDelta,
     *,
     skip_invalid: bool = False,
@@ -361,8 +361,8 @@ def _mf_series(
 @functools.wraps(series)
 def _get_series(
     DataFunction: "AdvancedTimeIndex",
-    start: pyearthtoolsDatetime,
-    end: pyearthtoolsDatetime,
+    start: Petdt,
+    end: Petdt,
     interval: TimeDelta,
     *,
     skip_invalid: bool = False,
@@ -438,8 +438,8 @@ def _get_series(
 
 def safe_series(
     DataFunction: "AdvancedTimeIndex",
-    start: str | pyearthtoolsDatetime,
-    end: str | pyearthtoolsDatetime,
+    start: str | Petdt,
+    end: str | Petdt,
     interval: TimeDelta,
     **kwargs,
 ) -> xr.Dataset:
@@ -455,9 +455,9 @@ def safe_series(
     Args:
         DataFunction (AdvancedTimeIndex):
             Data function, must be AdvancedTimeIndex or child
-        start (str | pyearthtoolsDatetime):
+        start (str | Petdt):
             Timestep to begin series at
-        end (str | pyearthtoolsDatetime):
+        end (str | Petdt):
             Timestep to end series at
         interval (TimeDelta):
             Time interval between samples. Use pandas.to_timedelta notation, (10, 'minute')
@@ -472,8 +472,8 @@ def safe_series(
     kwargs["skip_invalid"] = True
 
     interval = TimeDelta(interval)
-    start = pyearthtoolsDatetime(start)
-    end = pyearthtoolsDatetime(end)
+    start = Petdt(start)
+    end = Petdt(end)
 
     if DataFunction.data_resolution and time_delta_resolution(interval) > DataFunction.data_resolution:
         data: xr.Dataset = series(

--- a/packages/data/src/pyearthtools/data/patterns/direct.py
+++ b/packages/data/src/pyearthtools/data/patterns/direct.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from pyearthtools.data.time import pyearthtoolsDatetime, TimeResolution
+from pyearthtools.data.time import Petdt, TimeResolution
 from pyearthtools.data.patterns import (
     PatternIndex,
     PatternTimeIndex,
@@ -100,9 +100,9 @@ class _Direct(TimeIndex, PatternIndex):
 
     def filesystem(
         self,
-        basetime: str | pyearthtoolsDatetime,
+        basetime: str | Petdt,
     ) -> Path:
-        basetime = pyearthtoolsDatetime(basetime).at_resolution(self.file_resolution)
+        basetime = Petdt(basetime).at_resolution(self.file_resolution)
 
         basepath = Path(self.root_dir).resolve() / FILE_PATTERN.format(
             prefix=self.prefix + "_" if self.prefix else "",
@@ -146,9 +146,9 @@ class TemporalDirect(_Direct, PatternTimeIndex):
 
     def filesystem(
         self,
-        basetime: str | pyearthtoolsDatetime,
+        basetime: str | Petdt,
     ) -> Path:
-        basetime = pyearthtoolsDatetime(basetime)
+        basetime = Petdt(basetime)
 
         if self.data_resolution:
             basetime = basetime.at_resolution(self.data_resolution)

--- a/packages/data/src/pyearthtools/data/patterns/expanded_date.py
+++ b/packages/data/src/pyearthtools/data/patterns/expanded_date.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from pyearthtools.data import pyearthtoolsDatetime, TimeResolution
+from pyearthtools.data import Petdt, TimeResolution
 from pyearthtools.data.patterns.default import (
     PatternIndex,
     PatternTimeIndex,
@@ -115,10 +115,10 @@ class _ExpandedDate(PatternIndex):
 
     def filesystem(
         self,
-        basetime: str | pyearthtoolsDatetime,
+        basetime: str | Petdt,
     ) -> Path:
-        basetime = pyearthtoolsDatetime(basetime).at_resolution(self.file_resolution)
-        folder_datetime = pyearthtoolsDatetime(basetime).at_resolution(self.directory_resolution)
+        basetime = Petdt(basetime).at_resolution(self.file_resolution)
+        folder_datetime = Petdt(basetime).at_resolution(self.directory_resolution)
 
         basepath = Path(self.root_dir).resolve() / parse_time_str(
             folder_datetime, directory=True, delimiter=self.delimiter
@@ -177,12 +177,12 @@ class TemporalExpandedDate(_ExpandedDate, PatternTimeIndex):
 
     def filesystem(
         self,
-        basetime: str | pyearthtoolsDatetime,
+        basetime: str | Petdt,
     ) -> Path:
-        basetime = pyearthtoolsDatetime(basetime)
+        basetime = Petdt(basetime)
 
         basetime = basetime.at_resolution(self.file_resolution)
-        folder_datetime = pyearthtoolsDatetime(basetime).at_resolution(self.directory_resolution)
+        folder_datetime = Petdt(basetime).at_resolution(self.directory_resolution)
 
         basepath = Path(self.root_dir).resolve() / parse_time_str(folder_datetime, directory=True)
         basepath /= FILE_PATTERN.format(

--- a/packages/data/src/pyearthtools/data/time.py
+++ b/packages/data/src/pyearthtools/data/time.py
@@ -243,33 +243,49 @@ class pyearthtoolsMonthtime:
 
 @functools.total_ordering
 class Petdt:
-    """Datetime object with awareness of which values were set.
-
-    time must be a str or Petdt for resolution awareness to take effect,
-    If str, it must be in isoformat
-
-    Uses pandas.Datetime64 as underlying object.
-    But will return str of datetime using only what was set.
+    """
+    PyEarthTooils Datetime object which has additional functionality
+    relating to temporal resolution and resolution conversion compared
+    to other libraries, and also supports alternative calendars to
+    some degree.
 
     Examples:
-        >>> str(pyearthtools_datetime('2021-01'))
+        >>> str(Petdt('2021-01'))
         "2021-01"
-        >>> str(pyearthtools_datetime('2021-01-12'))
+        >>> str(Petdt('2021-01-12'))
         "2021-01-12"
     """
 
     def __init__(self, time: Any, *, resolution: str | TimeResolution | None = None):
         """
-        Datetime object with awareness of which values were set.
-
         Args:
-            time (Any):
-                Time to get resolution of. Can use 'today' to get today
-            resolution (str | TimeResolution | None, optional):
-                Override for resolution specification. Defaults to None.
+            time: Time to get resolution of. Can use 'today' to get today
+            resolution: Override for resolution specification. Defaults to None.
+
+        Notes:
+            time must be a str or Petdt for resolution awareness to take effect,
+            If str, it must be in isoformat        
+
+        Valid time resolutions are:
+            "year",
+            "month",
+            "day",
+            "hour",
+            "minute",
+            "second",
+            "nanosecond",            
+
+        Time when supplied as a string may be underspecified (e.g. just the year).
+        
+        The resolution of a supplied time string will be inferred from the 
+        time components which are present in the string.
+
+        If a resolution is specified lower than the specified time string,
+        the datetime will be down-sampled to match the specified resolution.
         """
 
-        _pandas_timestep = None
+        _pandas_timestep = None  # Internal storage object
+
         if isinstance(time, str) and time == "today":
             time = str(datetime.datetime.today().strftime("%Y-%m-%d"))
 
@@ -310,21 +326,11 @@ class Petdt:
         return np.datetime64(str(self), time_unit)
 
     @property
-    def qualified(self) -> pd.Timestamp:
-        """
-        Get fully qualified datetime of Petdt.
-
-        Uses underlying pandas.datetime object
-
-        """
-        return self._pandas_timestep
-
-    @property
     def datetime(self) -> datetime.datetime:
         """
         Get `datetime.datetime` object
         """
-        return datetime.datetime.fromisoformat(self.qualified.isoformat())
+        return datetime.datetime.fromisoformat(self._pandas_timestep.isoformat())
 
     def to_cftime(self, calendar="noleap"):
         """
@@ -385,7 +391,8 @@ class Petdt:
         elif isinstance(resolution, pd.Timedelta):
             resolution = time_delta_resolution(resolution)
 
-        return Petdt(self.qualified, resolution=resolution)
+        resampled = Petdt(self._pandas_timestep, resolution=resolution)
+        return resampled
 
     def __format__(self, *a):
         if len(a) == 0 or (len(a) == 1 and a[0] == ""):
@@ -588,7 +595,10 @@ class Petdt:
         return self._pandas_timestep > other
 
     def __eq__(self, other):
-        return self._pandas_timestep == other
+        # Rather than test identity on the fully-qualified object, the 
+        # Petdts should be compared according to their specified resolution
+        # Comparing the string representations will take care of this for now.
+        return str(self) == str(other)
 
 
 @functools.total_ordering

--- a/packages/data/src/pyearthtools/data/time.py
+++ b/packages/data/src/pyearthtools/data/time.py
@@ -264,7 +264,7 @@ class Petdt:
 
         Notes:
             time must be a str or Petdt for resolution awareness to take effect,
-            If str, it must be in isoformat        
+            If str, it must be in isoformat
 
         Valid time resolutions are:
             "year",
@@ -273,11 +273,11 @@ class Petdt:
             "hour",
             "minute",
             "second",
-            "nanosecond",            
+            "nanosecond",
 
         Time when supplied as a string may be underspecified (e.g. just the year).
-        
-        The resolution of a supplied time string will be inferred from the 
+
+        The resolution of a supplied time string will be inferred from the
         time components which are present in the string.
 
         If a resolution is specified lower than the specified time string,
@@ -510,9 +510,7 @@ class Petdt:
     def __sub__(self, other: Petdt) -> TimeDelta:
         ...
 
-    def __sub__(
-        self, other: Petdt | TimeDelta | int | datetime.timedelta
-    ) -> Petdt | TimeDelta:
+    def __sub__(self, other: Petdt | TimeDelta | int | datetime.timedelta) -> Petdt | TimeDelta:
         """
         Subtract from underlying '_pandas_timestep'.
 
@@ -595,7 +593,7 @@ class Petdt:
         return self._pandas_timestep > other
 
     def __eq__(self, other):
-        # Rather than test identity on the fully-qualified object, the 
+        # Rather than test identity on the fully-qualified object, the
         # Petdts should be compared according to their specified resolution
         # Comparing the string representations will take care of this for now.
         return str(self) == str(other)

--- a/packages/data/src/pyearthtools/data/time.py
+++ b/packages/data/src/pyearthtools/data/time.py
@@ -17,7 +17,7 @@
 # Datetime Overrides
 
 As the default datetime objects contain no reference to the user provided string, the resolution of time
-that a user provides is simply lost. [pyearthtoolsDatetime][pyearthtools.data.time.pyearthtoolsDatetime] introduces this concept as a wrapper around
+that a user provides is simply lost. [Petdt][pyearthtools.data.time.Petdt] introduces this concept as a wrapper around
 [pandas.DatetimeIndex][pandas.to_datetime].
 
 Subsequently, a [TimeDelta][pyearthtools.data.time.TimeDelta], and an override for range [TimeRange][pyearthtools.data.time.TimeRange] are also provided.
@@ -135,13 +135,13 @@ class TimeResolution:
 
     def __init__(
         self,
-        value: dict[VALID_RESOLUTIONS, bool] | VALID_RESOLUTIONS | str | "pyearthtoolsDatetime" | TimeResolution,
+        value: dict[VALID_RESOLUTIONS, bool] | VALID_RESOLUTIONS | str | "Petdt" | TimeResolution,
     ):
         """
-        Find resolution of pyearthtoolsDatetime or time string
+        Find resolution of Petdt or time string
 
         Args:
-            value (dict[VALID_RESOLUTIONS, bool] | VALID_RESOLUTIONS | str | pyearthtoolsDatetime | TimeResolution):
+            value (dict[VALID_RESOLUTIONS, bool] | VALID_RESOLUTIONS | str | Petdt | TimeResolution):
                 Value to find components from,
                 If dict, must be True or False for each component
                 If str, must be either date str.
@@ -164,10 +164,10 @@ class TimeResolution:
             if strip_to_common_resolution(value) in RESOLUTION_COMPONENTS:
                 resolution = strip_to_common_resolution(value)  # type: ignore
 
-            elif pyearthtoolsDatetime.is_time(value):
-                value = pyearthtoolsDatetime(value)
+            elif Petdt.is_time(value):
+                value = Petdt(value)
 
-        if isinstance(value, pyearthtoolsDatetime):
+        if isinstance(value, Petdt):
             resolution = value.resolution.resolution
 
         if resolution is None:
@@ -237,15 +237,15 @@ class TimeResolution:
 
 
 class pyearthtoolsMonthtime:
-    def __init__(self, input_month: str | pyearthtoolsMonthtime | pyearthtoolsDatetime) -> None:
+    def __init__(self, input_month: str | pyearthtoolsMonthtime | Petdt) -> None:
         raise NotImplementedError()
 
 
 @functools.total_ordering
-class pyearthtoolsDatetime:
+class Petdt:
     """Datetime object with awareness of which values were set.
 
-    time must be a str or pyearthtoolsDatetime for resolution awareness to take effect,
+    time must be a str or Petdt for resolution awareness to take effect,
     If str, it must be in isoformat
 
     Uses pandas.Datetime64 as underlying object.
@@ -273,7 +273,7 @@ class pyearthtoolsDatetime:
         if isinstance(time, str) and time == "today":
             time = str(datetime.datetime.today().strftime("%Y-%m-%d"))
 
-        elif isinstance(time, pyearthtoolsDatetime) or isinstance(time, type(self)):
+        elif isinstance(time, Petdt) or isinstance(time, type(self)):
             self._pandas_timestep = time._pandas_timestep
             self.resolution = time.resolution
             return
@@ -298,7 +298,7 @@ class pyearthtoolsDatetime:
 
     def datetime64(self, time_unit: str = "ns") -> np.datetime64:
         """
-        Get pyearthtoolsDatetime as a `np.datetime64` in given unit
+        Get Petdt as a `np.datetime64` in given unit
 
         Args:
             time_unit (str, optional): Time unit to get datetime64 in. Defaults to "ns".
@@ -312,7 +312,7 @@ class pyearthtoolsDatetime:
     @property
     def qualified(self) -> pd.Timestamp:
         """
-        Get fully qualified datetime of pyearthtoolsDatetime.
+        Get fully qualified datetime of Petdt.
 
         Uses underlying pandas.datetime object
 
@@ -341,33 +341,33 @@ class pyearthtoolsDatetime:
     @staticmethod
     def is_time(time_to_parse: Any) -> bool:
         """
-        Check if object can be parsed to a `pyearthtoolsDatetime`
+        Check if object can be parsed to a `Petdt`
 
-        Attempts to make `pyearthtoolsDatetime` but catches all exceptions.
+        Attempts to make `Petdt` but catches all exceptions.
 
         Args:
             time_to_parse (Any):
-                Object to check if can be `pyearthtoolsDatetime`
+                Object to check if can be `Petdt`
 
         Returns:
             (bool):
-                Boolean value of if can be `pyearthtoolsDatetime`
+                Boolean value of if can be `Petdt`
         """
         try:
-            pyearthtoolsDatetime(time_to_parse)
+            Petdt(time_to_parse)
             return True
         except Exception as e:
             return False
 
     def at_resolution(
         self,
-        resolution: VALID_RESOLUTIONS | pyearthtoolsDatetime | TimeResolution | TimeDelta | str,
-    ) -> pyearthtoolsDatetime:
+        resolution: VALID_RESOLUTIONS | Petdt | TimeResolution | TimeDelta | str,
+    ) -> Petdt:
         """
-        Get pyearthtoolsDatetime at specified resolution
+        Get Petdt at specified resolution
 
         Args:
-            resolution (VALID_RESOLUTIONS | pyearthtoolsDatetime | TimeResolution | TimeDelta, optional):
+            resolution (VALID_RESOLUTIONS | Petdt | TimeResolution | TimeDelta, optional):
                 Temporal Resolution of resulting pyearthtools_datetime.
 
         Raises:
@@ -375,17 +375,17 @@ class pyearthtoolsDatetime:
                 If `resolution` is not recognised
 
         Returns:
-            (pyearthtoolsDatetime):
-                pyearthtoolsDatetime at given resolution
+            (Petdt):
+                Petdt at given resolution
         """
 
-        if isinstance(resolution, (TimeDelta, pyearthtoolsDatetime)):
+        if isinstance(resolution, (TimeDelta, Petdt)):
             resolution = resolution.resolution
 
         elif isinstance(resolution, pd.Timedelta):
             resolution = time_delta_resolution(resolution)
 
-        return pyearthtoolsDatetime(self.qualified, resolution=resolution)
+        return Petdt(self.qualified, resolution=resolution)
 
     def __format__(self, *a):
         if len(a) == 0 or (len(a) == 1 and a[0] == ""):
@@ -422,7 +422,7 @@ class pyearthtoolsDatetime:
         return date_part + ("T" if time_part else "") + time_part
 
     def __repr__(self):
-        return f"pyearthtoolsDatetime({str(self)!r})"
+        return f"Petdt({str(self)!r})"
 
     def __getattr__(self, key):
         if key == "_pandas_timestep":
@@ -447,7 +447,7 @@ class pyearthtoolsDatetime:
     ###---------------###
     # Math
     ###---------------###
-    def __add__(self, other: pyearthtoolsDatetime | TimeDelta | int) -> pyearthtoolsDatetime:
+    def __add__(self, other: Petdt | TimeDelta | int) -> Petdt:
         """
         Add to underlying '_pandas_timestep'.
 
@@ -489,23 +489,23 @@ class pyearthtoolsDatetime:
         # if isinstance(new_timestep, pd.Timedelta):
         #     return new_timestep
 
-        new_pyearthtools_datetime = pyearthtoolsDatetime(new_timestep, resolution=max(self.resolution, resolution))
+        new_pyearthtools_datetime = Petdt(new_timestep, resolution=max(self.resolution, resolution))
         return new_pyearthtools_datetime
 
-    def __radd__(self, other: pyearthtoolsDatetime | TimeDelta | int) -> pyearthtoolsDatetime:
+    def __radd__(self, other: Petdt | TimeDelta | int) -> Petdt:
         return self.__add__(other)
 
     @overload
-    def __sub__(self, other: TimeDelta | int | datetime.timedelta) -> pyearthtoolsDatetime:
+    def __sub__(self, other: TimeDelta | int | datetime.timedelta) -> Petdt:
         ...
 
     @overload
-    def __sub__(self, other: pyearthtoolsDatetime) -> TimeDelta:
+    def __sub__(self, other: Petdt) -> TimeDelta:
         ...
 
     def __sub__(
-        self, other: pyearthtoolsDatetime | TimeDelta | int | datetime.timedelta
-    ) -> pyearthtoolsDatetime | TimeDelta:
+        self, other: Petdt | TimeDelta | int | datetime.timedelta
+    ) -> Petdt | TimeDelta:
         """
         Subtract from underlying '_pandas_timestep'.
 
@@ -549,7 +549,7 @@ class pyearthtoolsDatetime:
             new_timestep = self._pandas_timestep - other
             # resolution: TimeResolution = other.resolution
 
-        elif isinstance(other, pyearthtoolsDatetime):
+        elif isinstance(other, Petdt):
             new_timestep = TimeDelta(self._pandas_timestep - other._pandas_timestep)
             return new_timestep
         else:
@@ -559,11 +559,11 @@ class pyearthtoolsDatetime:
             # if isinstance(new_timestep, pd.Timedelta):
             #     return new_timestep
 
-        new_pyearthtools_datetime = pyearthtoolsDatetime(new_timestep, resolution=max(self.resolution, resolution))
+        new_pyearthtools_datetime = Petdt(new_timestep, resolution=max(self.resolution, resolution))
         return new_pyearthtools_datetime
 
-    def __rsub__(self, other: pyearthtoolsDatetime) -> pyearthtoolsDatetime | TimeDelta:
-        if not isinstance(other, pyearthtoolsDatetime):
+    def __rsub__(self, other: Petdt) -> Petdt | TimeDelta:
+        if not isinstance(other, Petdt):
             return NotImplemented
 
         new_timestep = other._pandas_timestep - self._pandas_timestep
@@ -572,7 +572,7 @@ class pyearthtoolsDatetime:
 
         resolution = TimeResolution("year")
 
-        new_pyearthtools_datetime = pyearthtoolsDatetime(new_timestep, resolution=max(self.resolution, resolution))
+        new_pyearthtools_datetime = Petdt(new_timestep, resolution=max(self.resolution, resolution))
         return new_pyearthtools_datetime
 
     def __hash__(self):
@@ -816,17 +816,17 @@ class _MonthTimeDelta(TimeDelta):
     #     return str([self.specified_month, self._input_timedelta[1]])
 
     def __radd__(self, other):
-        if isinstance(other, pyearthtoolsDatetime):
+        if isinstance(other, Petdt):
             new_date = other.at_resolution("month") + self.specified_month
-            if isinstance(new_date, pyearthtoolsDatetime):
+            if isinstance(new_date, Petdt):
                 return new_date.at_resolution(max(other.resolution, self.resolution))
             return new_date
         return super().__radd__(other)
 
     def __rsub__(self, other):
-        if isinstance(other, pyearthtoolsDatetime):
+        if isinstance(other, Petdt):
             new_date = other.at_resolution("month") - self.specified_month
-            if isinstance(new_date, pyearthtoolsDatetime):
+            if isinstance(new_date, Petdt):
                 return new_date.at_resolution(max(other.resolution, self.resolution))
         return super().__rsub__(other)
 
@@ -909,7 +909,7 @@ def time_delta_resolution(timedelta: pd.Timedelta | TimeDelta) -> TimeResolution
 
 
 @functools.lru_cache()
-def range_samples(start: pyearthtoolsDatetime, end: pyearthtoolsDatetime, step: TimeDelta, inclusive: bool = False):
+def range_samples(start: Petdt, end: Petdt, step: TimeDelta, inclusive: bool = False):
     """Cache generation of time samples"""
     samples = []
     current = start
@@ -932,8 +932,8 @@ class TimeRange:
 
     def __init__(
         self,
-        start: pyearthtoolsDatetime | str,
-        end: pyearthtoolsDatetime | str,
+        start: Petdt | str,
+        end: Petdt | str,
         step: TimeDelta | int | tuple | str,
         *,
         inclusive: bool = False,
@@ -944,9 +944,9 @@ class TimeRange:
         """Generate all timesteps between start & end at step interval.
 
         Args:
-            start (pyearthtoolsDatetime | str):
+            start (Petdt | str):
                 Starting time
-            end (pyearthtoolsDatetime | str):
+            end (Petdt | str):
                 Ending Time
             step (TimeDelta | int | tuple):
                 Step Interval
@@ -962,8 +962,8 @@ class TimeRange:
         if isinstance(end, str) and end == "current":
             end = datetime.datetime.today().strftime("%Y-%m-%d")
 
-        self.start = pyearthtoolsDatetime(start)
-        self.end = pyearthtoolsDatetime(end)
+        self.start = Petdt(start)
+        self.end = Petdt(end)
         self.step = TimeDelta(step)
 
         self.inclusive = inclusive
@@ -979,7 +979,7 @@ class TimeRange:
     def __len__(self):
         return len(range_samples(self.start, self.end, self.step, self.inclusive))
 
-    def __iter__(self) -> Generator[pyearthtoolsDatetime, None, None]:
+    def __iter__(self) -> Generator[Petdt, None, None]:
         samples = range_samples(self.start, self.end, self.step, self.inclusive)
 
         if self.use_tqdm:

--- a/packages/data/src/pyearthtools/data/transforms/normalisation/default.py
+++ b/packages/data/src/pyearthtools/data/transforms/normalisation/default.py
@@ -26,7 +26,7 @@ import xarray as xr
 
 import pyearthtools.data
 
-from pyearthtools.data import pyearthtoolsDatetime
+from pyearthtools.data import Petdt
 from pyearthtools.data.transforms.normalisation._utils import format_class_name
 from pyearthtools.data.transforms.transform import (
     FunctionTransform,
@@ -65,8 +65,8 @@ class normaliser:
     def __init__(
         self,
         index: pyearthtools.data.AdvancedTimeIndex,
-        start: pyearthtoolsDatetime | pyearthtoolsDatetime | None = None,
-        end: pyearthtoolsDatetime | pyearthtoolsDatetime | None = None,
+        start: Petdt | Petdt | None = None,
+        end: Petdt | Petdt | None = None,
         interval: int | tuple | None = None,
         *,
         override: str | Path | dict | None = None,
@@ -90,9 +90,9 @@ class normaliser:
         Args:
             index (pyearthtools.data.AdvancedTimeIndex, optional):
                 AdvancedTimeIndex being normalised, used to get aggregation & range
-            start (pyearthtoolsDatetime | pyearthtoolsDatetime, optional):
+            start (Petdt | Petdt, optional):
                 Start Date for retrieval
-            end (pyearthtoolsDatetime | pyearthtoolsDatetime, optional):
+            end (Petdt | Petdt, optional):
                 End Date for retrieval
             interval (int | tuple, optional):
                 Interval between samples. Use pandas.to_timedelta notation, (10, 'minute')

--- a/packages/data/tests/data/time/test_time.py
+++ b/packages/data/tests/data/time/test_time.py
@@ -39,6 +39,7 @@ def test_time_resolution_compatibility():
     assert str(dt1.at_resolution("day")) == '2023-05-03'
     assert str(dt2.at_resolution("day")) == '2023-05-03'
     assert str(dt1.at_resolution("day")) == str(dt2.at_resolution("day"))
+
     assert dt1.at_resolution("day") == dt2.at_resolution("day")  # But the same at daily resolution
 
 

--- a/packages/data/tests/data/time/test_time.py
+++ b/packages/data/tests/data/time/test_time.py
@@ -32,6 +32,16 @@ def test_time_resolution_change(basetime, resolution, expected):
     assert str(Petdt(basetime).at_resolution(resolution)) == expected
 
 
+def test_time_resolution_compatibility():
+    dt1 = Petdt('20230503T071500')
+    dt2 = Petdt('20230503T091500')
+    assert dt1 != dt2  # Confirm the datetime objects start life different
+    assert str(dt1.at_resolution("day")) == '2023-05-03'
+    assert str(dt2.at_resolution("day")) == '2023-05-03'
+    assert str(dt1.at_resolution("day")) == str(dt2.at_resolution("day"))
+    assert dt1.at_resolution("day") == dt2.at_resolution("day")  # But the same at daily resolution
+
+
 @pytest.mark.parametrize(
     "basetime, delta, expected",
     [

--- a/packages/data/tests/data/time/test_time.py
+++ b/packages/data/tests/data/time/test_time.py
@@ -33,11 +33,11 @@ def test_time_resolution_change(basetime, resolution, expected):
 
 
 def test_time_resolution_compatibility():
-    dt1 = Petdt('20230503T071500')
-    dt2 = Petdt('20230503T091500')
+    dt1 = Petdt("20230503T071500")
+    dt2 = Petdt("20230503T091500")
     assert dt1 != dt2  # Confirm the datetime objects start life different
-    assert str(dt1.at_resolution("day")) == '2023-05-03'
-    assert str(dt2.at_resolution("day")) == '2023-05-03'
+    assert str(dt1.at_resolution("day")) == "2023-05-03"
+    assert str(dt2.at_resolution("day")) == "2023-05-03"
     assert str(dt1.at_resolution("day")) == str(dt2.at_resolution("day"))
 
     assert dt1.at_resolution("day") == dt2.at_resolution("day")  # But the same at daily resolution

--- a/packages/data/tests/data/time/test_time.py
+++ b/packages/data/tests/data/time/test_time.py
@@ -15,7 +15,7 @@
 
 import pytest
 
-from pyearthtools.data.time import pyearthtoolsDatetime, TimeDelta, TimeRange, TimeResolution
+from pyearthtools.data.time import Petdt, TimeDelta, TimeRange, TimeResolution
 
 
 @pytest.mark.parametrize(
@@ -24,12 +24,12 @@ from pyearthtools.data.time import pyearthtoolsDatetime, TimeDelta, TimeRange, T
         ("2020-01-01", "day", "2020-01-01"),
         ("2020-01-01", "month", "2020-01"),
         ("2020-01-01", TimeResolution("month"), "2020-01"),
-        ("2020-01-01", pyearthtoolsDatetime("1970-01"), "2020-01"),
+        ("2020-01-01", Petdt("1970-01"), "2020-01"),
         ("2020-01-01", "second", "2020-01-01T00:00:00"),
     ],
 )
 def test_time_resolution_change(basetime, resolution, expected):
-    assert str(pyearthtoolsDatetime(basetime).at_resolution(resolution)) == expected
+    assert str(Petdt(basetime).at_resolution(resolution)) == expected
 
 
 @pytest.mark.parametrize(
@@ -46,7 +46,7 @@ def test_time_resolution_change(basetime, resolution, expected):
     ],
 )
 def test_time_addition(basetime, delta, expected):
-    assert str(pyearthtoolsDatetime(basetime) + TimeDelta(delta)) == expected
+    assert str(Petdt(basetime) + TimeDelta(delta)) == expected
 
 
 @pytest.mark.parametrize(
@@ -87,7 +87,7 @@ def test_range(start, end, interval, length):
     ],
 )
 def test_resolution(time, expected_resolution):
-    assert str(pyearthtoolsDatetime(time).resolution) == expected_resolution
+    assert str(Petdt(time).resolution) == expected_resolution
 
 
 @pytest.mark.parametrize(
@@ -114,4 +114,4 @@ def test_added_resolution(init_resolution, addition, expected_resolution):
     ],
 )
 def test_f_str(time, str_format, expected):
-    assert f"{pyearthtoolsDatetime(time):{str_format}}" == expected
+    assert f"{Petdt(time):{str_format}}" == expected

--- a/packages/pipeline/src/pyearthtools/pipeline/iterators.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/iterators.py
@@ -178,10 +178,10 @@ class DateRange(Iterator):
         Args:
             start (str):
                 Start time. Must be understandable by
-                `pyearthtools.data.pyearthtoolsDatetime`.
+                `pyearthtools.data.Petdt`.
             end (str):
                 End time. Must be understandable by
-                `pyearthtools.data.pyearthtoolsDatetime`.
+                `pyearthtools.data.Petdt`.
             interval (Any):
                 Interval between times. Must be understandable by
                 `pyearthtools.data.TimeDelta`.
@@ -193,7 +193,7 @@ class DateRange(Iterator):
 
         self._timerange = pyearthtools.data.TimeRange(start, end, interval)
 
-    def __iter__(self) -> Generator[pyearthtools.data.pyearthtoolsDatetime, None, None]:
+    def __iter__(self) -> Generator[pyearthtools.data.Petdt, None, None]:
         for i in self._timerange:
             yield i
 
@@ -219,7 +219,7 @@ class DateRangeLimit(DateRange):
                 Number of total samples to iterate over.
         """
 
-        end = pyearthtools.data.pyearthtoolsDatetime(start) + (pyearthtools.data.TimeDelta(interval) * num)
+        end = pyearthtools.data.Petdt(start) + (pyearthtools.data.TimeDelta(interval) * num)
         super().__init__(start, str(end), interval)
 
 

--- a/packages/pipeline/src/pyearthtools/pipeline/modifications/idx_modification.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/modifications/idx_modification.py
@@ -429,7 +429,7 @@ class SequenceRetrieval(IdxModifier):
 class TemporalRetrieval(SequenceRetrieval):
     """
     Retrieve a sequence of samples from `SequenceRetrieval`,
-    but force all indexes to be an `pyearthtools.data.pyearthtoolsDatetime`.
+    but force all indexes to be an `pyearthtools.data.Petdt`.
 
     Examples:
         >>> TemporalRetrieval(-6)['2000-01-01T12']
@@ -456,9 +456,9 @@ class TemporalRetrieval(SequenceRetrieval):
             self._modification = map_to_tuple(self._modification)
 
     def __getitem__(self, idx: Any):
-        if not isinstance(idx, pyearthtools.data.pyearthtoolsDatetime):
-            if not pyearthtools.data.pyearthtoolsDatetime.is_time(idx):
-                raise TypeError(f"Cannot convert {idx!r} to `pyearthtools.data.pyearthtoolsDatetime`.")
-            idx = pyearthtools.data.pyearthtoolsDatetime(idx)
+        if not isinstance(idx, pyearthtools.data.Petdt):
+            if not pyearthtools.data.Petdt.is_time(idx):
+                raise TypeError(f"Cannot convert {idx!r} to `pyearthtools.data.Petdt`.")
+            idx = pyearthtools.data.Petdt(idx)
 
         return super().__getitem__(idx)

--- a/packages/pipeline/tests/pipeline/test_idx_mod.py
+++ b/packages/pipeline/tests/pipeline/test_idx_mod.py
@@ -161,9 +161,7 @@ def test_TimeIdxModifier_basic():
     import pyearthtools.data
 
     pipe = Pipeline(FakeIndex(), modifications.TimeIdxModifier("6 hours"))
-    assert pipe[pyearthtools.data.Petdt("2000-01-01T00")] == pyearthtools.data.Petdt(
-        "2000-01-01T06"
-    )
+    assert pipe[pyearthtools.data.Petdt("2000-01-01T00")] == pyearthtools.data.Petdt("2000-01-01T06")
 
 
 # def test_TimeIdxModifier_basic_tuple():

--- a/packages/pipeline/tests/pipeline/test_idx_mod.py
+++ b/packages/pipeline/tests/pipeline/test_idx_mod.py
@@ -161,7 +161,7 @@ def test_TimeIdxModifier_basic():
     import pyearthtools.data
 
     pipe = Pipeline(FakeIndex(), modifications.TimeIdxModifier("6 hours"))
-    assert pipe[pyearthtools.data.pyearthtoolsDatetime("2000-01-01T00")] == pyearthtools.data.pyearthtoolsDatetime(
+    assert pipe[pyearthtools.data.Petdt("2000-01-01T00")] == pyearthtools.data.Petdt(
         "2000-01-01T06"
     )
 
@@ -169,14 +169,14 @@ def test_TimeIdxModifier_basic():
 # def test_TimeIdxModifier_basic_tuple():
 #     import pyearthtools.data
 #     pipe = Pipeline(FakeIndex(), pipelines.TimeIdxModifier((6, 'hours')))
-#     assert pipe[pyearthtools.data.pyearthtoolsDatetime('2000-01-01T00')] == pyearthtools.data.pyearthtoolsDatetime('2000-01-01T06')
+#     assert pipe[pyearthtools.data.Petdt('2000-01-01T00')] == pyearthtools.data.Petdt('2000-01-01T06')
 
 
 def test_TimeIdxModifier_nested():
     import pyearthtools.data
 
     pipe = Pipeline(FakeIndex(), modifications.TimeIdxModifier(("6 hours", "12 hours")))
-    assert pipe[pyearthtools.data.pyearthtoolsDatetime("2000-01-01T00")] == (
-        pyearthtools.data.pyearthtoolsDatetime("2000-01-01T06"),
-        pyearthtools.data.pyearthtoolsDatetime("2000-01-01T12"),
+    assert pipe[pyearthtools.data.Petdt("2000-01-01T00")] == (
+        pyearthtools.data.Petdt("2000-01-01T06"),
+        pyearthtools.data.Petdt("2000-01-01T12"),
     )

--- a/packages/training/src/pyearthtools/training/dataindex.py
+++ b/packages/training/src/pyearthtools/training/dataindex.py
@@ -27,7 +27,7 @@ import yaml
 from typing import Any
 
 import pyearthtools.data
-from pyearthtools.data import pyearthtoolsDatetime, Transform, TransformCollection, TimeDelta
+from pyearthtools.data import Petdt, Transform, TransformCollection, TimeDelta
 from pyearthtools.data.indexes import TimeIndex
 from pyearthtools.data.indexes.cacheIndex import BaseCacheIndex
 
@@ -112,7 +112,7 @@ class MLDataIndex(BaseCacheIndex, TimeIndex):
         self.offsetInterval = offsetInterval
         self._override = override
 
-    def offset_time(self, time: str | pyearthtoolsDatetime) -> pyearthtoolsDatetime:
+    def offset_time(self, time: str | Petdt) -> Petdt:
         """
         Offset the time given
 
@@ -121,26 +121,26 @@ class MLDataIndex(BaseCacheIndex, TimeIndex):
         Otherwise offset by `offsetInterval`.
 
         Args:
-            time (str | pyearthtoolsDatetime):
+            time (str | Petdt):
                 Time to offset
 
         Returns:
-            (pyearthtoolsDatetime):
+            (Petdt):
                 Offset time
         """
-        time = pyearthtoolsDatetime(time)
+        time = Petdt(time)
         if self.offsetInterval:
             if self.data_interval and isinstance(self.offsetInterval, bool):
-                time = pyearthtoolsDatetime(time) + (
+                time = Petdt(time) + (
                     self.data_interval if not isinstance(self.data_interval, str) else TimeDelta(self.data_interval)
                 )
             else:
-                time = pyearthtoolsDatetime(time) + TimeDelta(self.offsetInterval)
-        return pyearthtoolsDatetime(time)
+                time = Petdt(time) + TimeDelta(self.offsetInterval)
+        return Petdt(time)
 
     def _generate(
         self,
-        querytime: str | pyearthtoolsDatetime,
+        querytime: str | Petdt,
     ) -> Any:
         """
         Get Data from given timestep

--- a/packages/training/src/pyearthtools/training/wrapper/predict/timeseries.py
+++ b/packages/training/src/pyearthtools/training/wrapper/predict/timeseries.py
@@ -26,7 +26,7 @@ import tqdm.auto as tqdm
 import logging
 
 
-from pyearthtools.data import TimeDelta, pyearthtoolsDatetime, TimeRange
+from pyearthtools.data import TimeDelta, Petdt, TimeRange
 
 from pyearthtools.pipeline.controller import Pipeline
 from pyearthtools.training.wrapper.wrapper import ModelWrapper
@@ -117,7 +117,7 @@ class TimeSeriesPredictor(Predictor):
 
         interval = TimeDelta(self._interval)
 
-        idx = pyearthtoolsDatetime(idx) + (interval * offset)
+        idx = Petdt(idx) + (interval * offset)
         len_time = len(data[self._time_dim])
 
         time_coord = list(map(lambda x: x.datetime64(), TimeRange(idx, idx + (interval * len_time), interval)))
@@ -475,7 +475,7 @@ class TimeSeriesManagedPredictor(TimeSeriesAutoRecurrentPredictor):
                     for key, val in self.variable_manager.split(model_output_shaped, self._output_order).items()
                 }
 
-            current_time_step = pyearthtoolsDatetime(idx) + (
+            current_time_step = Petdt(idx) + (
                 self._interval * step * model_output.shape[self._combine_axis]
             )
             outputs.append(model_output)

--- a/packages/training/src/pyearthtools/training/wrapper/predict/timeseries.py
+++ b/packages/training/src/pyearthtools/training/wrapper/predict/timeseries.py
@@ -475,9 +475,7 @@ class TimeSeriesManagedPredictor(TimeSeriesAutoRecurrentPredictor):
                     for key, val in self.variable_manager.split(model_output_shaped, self._output_order).items()
                 }
 
-            current_time_step = Petdt(idx) + (
-                self._interval * step * model_output.shape[self._combine_axis]
-            )
+            current_time_step = Petdt(idx) + (self._interval * step * model_output.shape[self._combine_axis])
             outputs.append(model_output)
 
             output_components = self.prepare_output(output_components)

--- a/packages/training/src/pyearthtools/training/wrapper/utils.py
+++ b/packages/training/src/pyearthtools/training/wrapper/utils.py
@@ -19,7 +19,7 @@ import functools
 from typing import Callable
 import math
 
-from pyearthtools.data import TimeDelta, pyearthtoolsDatetime
+from pyearthtools.data import TimeDelta, Petdt
 
 
 def parse_recurrent(interval: int | TimeDelta = 1):
@@ -60,7 +60,7 @@ def parse_recurrent(interval: int | TimeDelta = 1):
                 kwargs["steps"] = math.ceil(time / interval)
             elif "to_time" in kwargs:
                 to_time = kwargs.pop("to_time")
-                kwargs["steps"] = math.ceil((pyearthtoolsDatetime("current") - to_time) / interval)
+                kwargs["steps"] = math.ceil((Petdt("current") - to_time) / interval)
             return func(*args, **kwargs)
 
         return parse

--- a/packages/tutorial/src/pyearthtools/tutorial/ERA5DataClass.py
+++ b/packages/tutorial/src/pyearthtools/tutorial/ERA5DataClass.py
@@ -35,7 +35,7 @@ from typing import Any, Literal
 
 import pyearthtools.data
 
-from pyearthtools.data import pyearthtoolsDatetime
+from pyearthtools.data import Petdt
 from pyearthtools.data.exceptions import DataNotFoundError
 from pyearthtools.data.indexes import ArchiveIndex, decorators
 from pyearthtools.data.transforms import Transform, TransformCollection
@@ -151,7 +151,7 @@ class ERA5LowResIndex(ArchiveIndex):
 
     def filesystem(
         self,
-        querytime: str | pyearthtoolsDatetime,
+        querytime: str | Petdt,
     ) -> Path | dict[str, str | Path]:
         ERA5_HOME = self.ROOT_DIRECTORIES["era5lowres"]
 
@@ -161,7 +161,7 @@ class ERA5LowResIndex(ArchiveIndex):
         """
 
         paths = {}
-        querytime = pyearthtoolsDatetime(querytime)
+        querytime = Petdt(querytime)
 
         for variable in self.variables:
 


### PR DESCRIPTION
This PR does the following:
 - Renames `pyearthtoolsDatetime` to `Petdt`, which is (a) less verbose and (b) follows case conventions for classes
 - Corrects a defect in the equality operator implementation (see issue #60 )
 - Improves some docstrings
 - Removes an un-necessary property object which was only used once, internally
 - Adds more testing on the equality operation
 - Improves code coverage in time.py by 1%