### PR TITLE
Update import statement to be isort compliant

### DIFF
--- a/packages/data/.pre-commit-config.yaml
+++ b/packages/data/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v3.2.0
     hooks:
     -   id: check-yaml
     -   id: end-of-file-fixer

--- a/packages/data/.pre-commit-config.yaml
+++ b/packages/data/.pre-commit-config.yaml
@@ -1,32 +1,36 @@
----
-# See https://pre-commit.com for more information
-# See https://pre-commit.com/hooks.html for more hooks
 repos:
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
     hooks:
-      - id: trailing-whitespace
-      - id: end-of-file-fixer
-      - id: check-yaml
-      - id: check-added-large-files
-        args: ['--maxkb=10485760']
-      - id: check-byte-order-marker
-      - id: check-executables-have-shebangs
-  - repo: https://github.com/psf/black
-    rev: 22.3.0
+    -   id: check-yaml
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+-   repo: https://github.com/psf/black
+    rev: 22.10.0
     hooks:
-      - id: black
-        args: ['--line-length', '120']
-  # - repo: https://github.com/PyCQA/flake8
-  #   rev: 3.9.2
-  #   hooks:
-  #     - id: flake8
-  #       args: ['--max-line-length', '120', "--extend-ignore", "E203"]
-  - repo: https://github.com/Quantco/pre-commit-mirrors-shellcheck
-    rev: 0.7.1
+    -   id: black
+-   repo: https://github.com/pycqa/isort
+    rev: 6.0.1
     hooks:
-      - id: shellcheck-conda
-  - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.64.0
-    hooks:
-      - id: terraform_validate
+    -   id: isort
+
+
+# ---
+# # See https://pre-commit.com for more information
+# # See https://pre-commit.com/hooks.html for more hooks
+# repos:
+#   - repo: https://github.com/pre-commit/pre-commit-hooks
+#     rev: v3.2.0
+#     hooks:
+#       - id: trailing-whitespace
+#       - id: end-of-file-fixer
+#       - id: check-yaml
+#       - id: check-added-large-files
+#         args: ['--maxkb=10485760']
+#       - id: check-byte-order-marker
+#       - id: check-executables-have-shebangs
+#   - repo: https://github.com/psf/black
+#     rev: 22.3.0
+#     hooks:
+#       - id: black
+#         args: ['--line-length', '120']

--- a/packages/data/.pre-commit-config.yaml
+++ b/packages/data/.pre-commit-config.yaml
@@ -33,4 +33,17 @@ repos:
 #     rev: 22.3.0
 #     hooks:
 #       - id: black
-#         args: ['--line-length', '120']
+#   # - repo: https://github.com/PyCQA/flake8
+#   #   rev: 3.9.2
+#   #   hooks:
+#   #     - id: flake8
+#   #       args: ['--max-line-length', '120', "--extend-ignore", "E203"]
+#   - repo: https://github.com/Quantco/pre-commit-mirrors-shellcheck
+#     rev: 0.7.1
+#     hooks:
+#       - id: shellcheck-conda
+#   - repo: https://github.com/antonbabenko/pre-commit-terraform
+#     rev: v1.64.0
+#     hooks:
+#       - id: terraform_validate
+

--- a/packages/data/src/pyearthtools/data/__init__.py
+++ b/packages/data/src/pyearthtools/data/__init__.py
@@ -92,16 +92,10 @@ from pyearthtools.data import (
 )
 from pyearthtools.data import operations
 from pyearthtools.data import operations as op
-from pyearthtools.data import (
-    patterns,
-    save,
-    static,
-)
+from pyearthtools.data import patterns, save, static
 from pyearthtools.data import transforms
 from pyearthtools.data import transforms as transform
-from pyearthtools.data import (
-    utils,
-)
+from pyearthtools.data import utils
 from pyearthtools.data.archive.utils import auto_import
 from pyearthtools.data.collection import Collection, LabelledCollection
 from pyearthtools.data.exceptions import DataNotFoundError, InvalidIndexError

--- a/packages/data/src/pyearthtools/data/__init__.py
+++ b/packages/data/src/pyearthtools/data/__init__.py
@@ -78,65 +78,71 @@ At the moment, data is confined to geospatial netcdf sources.
 
 __version__ = "0.1.0"
 
-from pyearthtools.data import logger
-from pyearthtools.data import config
+import warnings as __python_warnings
 
-from pyearthtools.data.time import Petdt, TimeResolution, TimeDelta, TimeRange
-from pyearthtools.data.time import Petdt as datetime
-
+import pyearthtools.utils
+from pyearthtools.data import (
+    archive,
+    config,
+    derived,
+    download,
+    indexes,
+    logger,
+    modifications,
+)
+from pyearthtools.data import operations
+from pyearthtools.data import operations as op
+from pyearthtools.data import (
+    patterns,
+    save,
+    static,
+)
+from pyearthtools.data import transforms
+from pyearthtools.data import transforms as transform
+from pyearthtools.data import (
+    utils,
+)
+from pyearthtools.data.archive.utils import auto_import
+from pyearthtools.data.collection import Collection, LabelledCollection
 from pyearthtools.data.exceptions import DataNotFoundError, InvalidIndexError
+from pyearthtools.data.indexes import (
+    AdvancedTimeDataIndex,
+    AdvancedTimeIndex,
+    ArchiveIndex,
+    BaseTimeIndex,
+    CachingForecastIndex,
+    CachingIndex,
+    DataFileSystemIndex,
+    DataIndex,
+    FileSystemIndex,
+    ForecastIndex,
+    Index,
+    IntakeIndex,
+    IntakeIndexCache,
+    StaticDataIndex,
+    TimeIndex,
+    register_accessor,
+)
+from pyearthtools.data.load import load
+from pyearthtools.data.patterns import PatternIndex
+from pyearthtools.data.save import ManageFiles, ManageTemp
+from pyearthtools.data.time import Petdt
+from pyearthtools.data.time import Petdt as datetime
+from pyearthtools.data.time import TimeDelta, TimeRange, TimeResolution
+from pyearthtools.data.transforms.derive import evaluate
+from pyearthtools.data.transforms.transform import (
+    FunctionTransform,
+    Transform,
+    TransformCollection,
+)
 from pyearthtools.data.warnings import (
+    AccessorRegistrationWarning,
     IndexWarning,
     pyearthtoolsDataWarning,
-    AccessorRegistrationWarning,
 )
-
-
-from pyearthtools.data.collection import Collection, LabelledCollection
 
 # from pyearthtools.data.catalog import Catalog, CatalogEntry
 
-from pyearthtools.data.indexes import (
-    Index,
-    DataIndex,
-    FileSystemIndex,
-    TimeIndex,
-    AdvancedTimeIndex,
-    AdvancedTimeDataIndex,
-    BaseTimeIndex,
-    DataFileSystemIndex,
-    ArchiveIndex,
-    ForecastIndex,
-    StaticDataIndex,
-    CachingIndex,
-    CachingForecastIndex,
-    IntakeIndex,
-    IntakeIndexCache,
-)
-from pyearthtools.data import indexes
-from pyearthtools.data.indexes import register_accessor
-
-from pyearthtools.data import operations as op
-
-from pyearthtools.data import archive, operations, static, transforms, patterns, download, modifications, derived, utils
-from pyearthtools.data import transforms as transform
-from pyearthtools.data.patterns import PatternIndex
-
-from pyearthtools.data.transforms.transform import (
-    Transform,
-    TransformCollection,
-    FunctionTransform,
-)
-from pyearthtools.data.transforms.derive import evaluate
-from pyearthtools.data import save
-from pyearthtools.data.save import ManageFiles, ManageTemp
-
-from pyearthtools.data.load import load
-
-import pyearthtools.utils
-import warnings as __python_warnings
-
-from pyearthtools.data.archive.utils import auto_import
 
 """Auto import archives if available"""
 

--- a/packages/data/src/pyearthtools/data/__init__.py
+++ b/packages/data/src/pyearthtools/data/__init__.py
@@ -92,10 +92,16 @@ from pyearthtools.data import (
 )
 from pyearthtools.data import operations
 from pyearthtools.data import operations as op
-from pyearthtools.data import patterns, save, static
+from pyearthtools.data import (
+    patterns,
+    save,
+    static,
+)
 from pyearthtools.data import transforms
 from pyearthtools.data import transforms as transform
-from pyearthtools.data import utils
+from pyearthtools.data import (
+    utils,
+)
 from pyearthtools.data.archive.utils import auto_import
 from pyearthtools.data.collection import Collection, LabelledCollection
 from pyearthtools.data.exceptions import DataNotFoundError, InvalidIndexError

--- a/packages/data/src/pyearthtools/data/archive/__init__.py
+++ b/packages/data/src/pyearthtools/data/archive/__init__.py
@@ -36,9 +36,7 @@ More archives can be added by wrapping a class with [register_archive][pyearthto
 """
 
 from pyearthtools.data.archive.extensions import register_archive
-
-from pyearthtools.data.archive.root import set_root, reset_root, config_root
-
+from pyearthtools.data.archive.root import config_root, reset_root, set_root
 
 ZARR_IMPORTED = True
 try:

--- a/packages/data/src/pyearthtools/data/archive/extensions.py
+++ b/packages/data/src/pyearthtools/data/archive/extensions.py
@@ -39,10 +39,9 @@ Examples:
 
 from __future__ import annotations
 
-from types import ModuleType
-from typing import Callable, Any
-
 import warnings
+from types import ModuleType
+from typing import Any, Callable
 
 import pyearthtools.data
 from pyearthtools.data import archive

--- a/packages/data/src/pyearthtools/data/archive/root.py
+++ b/packages/data/src/pyearthtools/data/archive/root.py
@@ -15,8 +15,8 @@
 
 from __future__ import annotations
 
-import warnings
 import logging
+import warnings
 
 import pyearthtools.data
 from pyearthtools.data import archive

--- a/packages/data/src/pyearthtools/data/archive/utils.py
+++ b/packages/data/src/pyearthtools/data/archive/utils.py
@@ -21,14 +21,13 @@ Allow archives to be autoimported if detected to be on the system in question.
 
 from __future__ import annotations
 
-from pathlib import Path
-import os
-import re
-
 import importlib
 import logging
-from typing import Any
+import os
+import re
 import warnings
+from pathlib import Path
+from typing import Any
 
 from pyearthtools.data import archive
 from pyearthtools.data.indexes.utilities.fileload import open_static

--- a/packages/data/src/pyearthtools/data/archive/zarr.py
+++ b/packages/data/src/pyearthtools/data/archive/zarr.py
@@ -21,23 +21,20 @@ Allows access and saving in zarr
 
 from __future__ import annotations
 
+import logging
+from os import PathLike
 from pathlib import Path
 from typing import Any, Literal
-from os import PathLike
 
-import xarray as xr
 import dask
-import logging
-
 import pyearthtools.data
+import xarray as xr
+from pyearthtools.data.indexes.indexes import DataFileSystemIndex, TimeIndex
+from pyearthtools.data.indexes.utilities.dimensions import identify_time_dimension
+from pyearthtools.data.save import save
 from pyearthtools.data.time import Petdt
 from pyearthtools.data.transforms import Transform, TransformCollection
-from pyearthtools.data.indexes.indexes import DataFileSystemIndex, TimeIndex
-
-from pyearthtools.data.indexes.utilities.dimensions import identify_time_dimension
 from pyearthtools.data.utils import parse_path
-
-from pyearthtools.data.save import save
 
 LOG = logging.getLogger("pyearthtools.data")
 

--- a/packages/data/src/pyearthtools/data/catalog.py
+++ b/packages/data/src/pyearthtools/data/catalog.py
@@ -191,7 +191,7 @@ class CatalogEntry:
             Converts non serialisable to serialisable
             """
             for key, value in kwargs.items():
-                if isinstance(value, (pyearthtools.data.TimeDelta, pyearthtools.data.TimeResolution, Path)):
+                if isinstance(value, (pyearthtools.data.time.TimeDelta, pyearthtools.data.TimeResolution, Path)):
                     kwargs[key] = str(value)
             return kwargs
 

--- a/packages/data/src/pyearthtools/data/catalog.py
+++ b/packages/data/src/pyearthtools/data/catalog.py
@@ -40,26 +40,22 @@ with the key being the class, and the value of the following form,
 """
 
 from __future__ import annotations
-from collections import OrderedDict
 
-from typing import Optional
-
-import yaml
+import io
 import json
-from pathlib import Path
-from typing import Any, Callable, Optional
 import types
 import warnings
+from collections import OrderedDict
 from functools import lru_cache
-import io
-
-from pyearthtools.utils.parsing import function_name
-from pyearthtools.utils.initialisation.imports import dynamic_import
+from pathlib import Path
+from typing import Any, Callable, Optional
 
 import pyearthtools.data
+import yaml
 from pyearthtools.data.collection import Collection, LabelledCollection
-
 from pyearthtools.utils.decorators import alias_arguments
+from pyearthtools.utils.initialisation.imports import dynamic_import
+from pyearthtools.utils.parsing import function_name
 
 UTILS_REPR = False
 try:

--- a/packages/data/src/pyearthtools/data/collection.py
+++ b/packages/data/src/pyearthtools/data/collection.py
@@ -22,10 +22,11 @@ Additional base data types included for use in `pyearthtools`
 """
 
 from __future__ import annotations
-from _collections_abc import dict_keys
 
-from typing import Any
 from collections import OrderedDict
+from typing import Any
+
+from _collections_abc import dict_keys
 
 
 class Collection(tuple):

--- a/packages/data/src/pyearthtools/data/commands.py
+++ b/packages/data/src/pyearthtools/data/commands.py
@@ -18,6 +18,7 @@ Command Line Interface for `pyearthtools.data`
 """
 
 from __future__ import annotations
+
 from pathlib import Path
 
 import click
@@ -98,8 +99,8 @@ def create_structure(top, blacklisted, save, verbose):
         top: Path
             Location to generate structure for
     """
-    from pyearthtools.data.indexes.utilities.structure import structure
     import yaml
+    from pyearthtools.data.indexes.utilities.structure import structure
 
     structure_dict: dict[str, dict | list] = {}
     structure_d: dict[str, dict[str, Any] | list[str]] = structure(top, blacklisted=blacklisted, verbose=verbose)  # type: ignore

--- a/packages/data/src/pyearthtools/data/derived/__init__.py
+++ b/packages/data/src/pyearthtools/data/derived/__init__.py
@@ -18,8 +18,11 @@ Calculated / Derived Value Indexes
 """
 
 
-from pyearthtools.data.derived.derived import DerivedValue, TimeDerivedValue, AdvancedTimeDerivedValue
+from pyearthtools.data.derived.derived import (
+    AdvancedTimeDerivedValue,
+    DerivedValue,
+    TimeDerivedValue,
+)
 from pyearthtools.data.derived.insolation import Insolation
-
 
 __all__ = ["DerivedValue", "TimeDerivedValue", "AdvancedTimeDerivedValue", "Insolation"]

--- a/packages/data/src/pyearthtools/data/derived/derived.py
+++ b/packages/data/src/pyearthtools/data/derived/derived.py
@@ -19,15 +19,13 @@ Derived Data
 
 from __future__ import annotations
 
-from typing import Union
 import inspect
-from abc import abstractmethod, ABCMeta
+from abc import ABCMeta, abstractmethod
+from typing import Union
 
 import xarray as xr
-
-
+from pyearthtools.data.indexes import AdvancedTimeDataIndex, DataIndex, TimeDataIndex
 from pyearthtools.data.time import Petdt, TimeDelta, TimeRange
-from pyearthtools.data.indexes import DataIndex, TimeDataIndex, AdvancedTimeDataIndex
 
 
 class DerivedValue(DataIndex, metaclass=ABCMeta):

--- a/packages/data/src/pyearthtools/data/derived/insolation.py
+++ b/packages/data/src/pyearthtools/data/derived/insolation.py
@@ -18,11 +18,9 @@
 
 from __future__ import annotations
 
-
 import numpy as np
-import xarray as xr
 import pandas as pd
-
+import xarray as xr
 from pyearthtools.data.derived.derived import AdvancedTimeDerivedValue
 
 DASK_IMPORTED = True

--- a/packages/data/src/pyearthtools/data/download/__init__.py
+++ b/packages/data/src/pyearthtools/data/download/__init__.py
@@ -27,6 +27,6 @@ Implemented:
 
 """
 
-from pyearthtools.data.download.templates import DownloadIndex
-from pyearthtools.data.download import cds, arco
+from pyearthtools.data.download import arco, cds
 from pyearthtools.data.download import ecmwf_opendata as opendata
+from pyearthtools.data.download.templates import DownloadIndex

--- a/packages/data/src/pyearthtools/data/download/arco/ERA5.py
+++ b/packages/data/src/pyearthtools/data/download/arco/ERA5.py
@@ -14,23 +14,20 @@
 
 
 from __future__ import annotations
-import functools
 
-import xarray as xr
+import functools
 from os import PathLike
 
 import pyearthtools.data
-from pyearthtools.data.time import Petdt
-
-from pyearthtools.data.indexes import AdvancedTimeDataIndex, decorators, CachingIndex
-from pyearthtools.data.transforms.transform import Transform, TransformCollection
-
-from pyearthtools.data.patterns.expanded_date import ExpandedDateVariable
-
+import xarray as xr
 from pyearthtools.data.download.arco.variables.ERA5 import (
     ERA5_LEVELS,
     ERA_NAME_CHANGE,
 )
+from pyearthtools.data.indexes import AdvancedTimeDataIndex, CachingIndex, decorators
+from pyearthtools.data.patterns.expanded_date import ExpandedDateVariable
+from pyearthtools.data.time import Petdt
+from pyearthtools.data.transforms.transform import Transform, TransformCollection
 
 ROOT_ARCO_DS = None
 

--- a/packages/data/src/pyearthtools/data/download/cds/ERA5.py
+++ b/packages/data/src/pyearthtools/data/download/cds/ERA5.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from typing import Literal, Optional, Union
 
 import pyearthtools.data
-from pyearthtools.data import Petdt
+from pyearthtools.data.time import Petdt
 from pyearthtools.data.download.cds._ERA5 import (
     ERA5_LEVELS,
     ERA_PRESSURE_NAME_CHANGE,

--- a/packages/data/src/pyearthtools/data/download/cds/ERA5.py
+++ b/packages/data/src/pyearthtools/data/download/cds/ERA5.py
@@ -18,25 +18,22 @@ ERA5 Copernicus Data Storage Index
 """
 
 from __future__ import annotations
-from typing import Literal, Union, Optional
-from pathlib import Path
-import warnings
 
+import warnings
+from pathlib import Path
+from typing import Literal, Optional, Union
 
 import pyearthtools.data
 from pyearthtools.data import Petdt
-from pyearthtools.data.warnings import pyearthtoolsDataWarning
-
-from pyearthtools.data.indexes import decorators
-from pyearthtools.data.transforms import Transform, TransformCollection
-
-from pyearthtools.data.download.cds.cds import root_cds, as_list
 from pyearthtools.data.download.cds._ERA5 import (
     ERA5_LEVELS,
     ERA_PRESSURE_NAME_CHANGE,
     ERA_SINGLE_NAME_CHANGE,
 )
-
+from pyearthtools.data.download.cds.cds import as_list, root_cds
+from pyearthtools.data.indexes import decorators
+from pyearthtools.data.transforms import Transform, TransformCollection
+from pyearthtools.data.warnings import pyearthtoolsDataWarning
 
 cds_type = [
     "ensemble_mean",

--- a/packages/data/src/pyearthtools/data/download/cds/ERA5.py
+++ b/packages/data/src/pyearthtools/data/download/cds/ERA5.py
@@ -24,7 +24,6 @@ from pathlib import Path
 from typing import Literal, Optional, Union
 
 import pyearthtools.data
-from pyearthtools.data.time import Petdt
 from pyearthtools.data.download.cds._ERA5 import (
     ERA5_LEVELS,
     ERA_PRESSURE_NAME_CHANGE,
@@ -32,6 +31,7 @@ from pyearthtools.data.download.cds._ERA5 import (
 )
 from pyearthtools.data.download.cds.cds import as_list, root_cds
 from pyearthtools.data.indexes import decorators
+from pyearthtools.data.time import Petdt
 from pyearthtools.data.transforms import Transform, TransformCollection
 from pyearthtools.data.warnings import pyearthtoolsDataWarning
 

--- a/packages/data/src/pyearthtools/data/download/cds/cds.py
+++ b/packages/data/src/pyearthtools/data/download/cds/cds.py
@@ -27,8 +27,9 @@ from typing import Any, Iterable, Type
 
 import urllib3
 import xarray as xr
-from pyearthtools.data import DataNotFoundError, Petdt
-from pyearthtools.data.download import DownloadIndex
+from pyearthtools.data.exceptions import DataNotFoundError
+from pyearthtools.data.time import Petdt
+from pyearthtools.data.download.templates import DownloadIndex
 from pyearthtools.data.indexes import utilities
 from pyearthtools.data.patterns import PatternIndex, TemporalExpandedDateVariable
 from pyearthtools.data.transforms import Transform, TransformCollection

--- a/packages/data/src/pyearthtools/data/download/cds/cds.py
+++ b/packages/data/src/pyearthtools/data/download/cds/cds.py
@@ -27,11 +27,11 @@ from typing import Any, Iterable, Type
 
 import urllib3
 import xarray as xr
-from pyearthtools.data.exceptions import DataNotFoundError
-from pyearthtools.data.time import Petdt
 from pyearthtools.data.download.templates import DownloadIndex
+from pyearthtools.data.exceptions import DataNotFoundError
 from pyearthtools.data.indexes import utilities
 from pyearthtools.data.patterns import PatternIndex, TemporalExpandedDateVariable
+from pyearthtools.data.time import Petdt
 from pyearthtools.data.transforms import Transform, TransformCollection
 
 LOG = logging.getLogger("pyearthtools.data")

--- a/packages/data/src/pyearthtools/data/download/cds/cds.py
+++ b/packages/data/src/pyearthtools/data/download/cds/cds.py
@@ -18,19 +18,19 @@ Copernicus Data Storage Root Index
 """
 
 from __future__ import annotations
-from abc import abstractmethod, ABCMeta
-from pathlib import Path
-from typing import Iterable, Any, Type
-import xarray as xr
+
 import logging
 import warnings
+from abc import ABCMeta, abstractmethod
+from pathlib import Path
+from typing import Any, Iterable, Type
 
 import urllib3
-
+import xarray as xr
 from pyearthtools.data import DataNotFoundError, Petdt
 from pyearthtools.data.download import DownloadIndex
 from pyearthtools.data.indexes import utilities
-from pyearthtools.data.patterns import TemporalExpandedDateVariable, PatternIndex
+from pyearthtools.data.patterns import PatternIndex, TemporalExpandedDateVariable
 from pyearthtools.data.transforms import Transform, TransformCollection
 
 LOG = logging.getLogger("pyearthtools.data")

--- a/packages/data/src/pyearthtools/data/download/ecmwf_opendata/__init__.py
+++ b/packages/data/src/pyearthtools/data/download/ecmwf_opendata/__init__.py
@@ -17,5 +17,5 @@
 ECMWF OpenData
 """
 
-from pyearthtools.data.download.ecmwf_opendata.opendata import OpenData
 from pyearthtools.data.download.ecmwf_opendata.convenience import AIFS, IFS
+from pyearthtools.data.download.ecmwf_opendata.opendata import OpenData

--- a/packages/data/src/pyearthtools/data/download/ecmwf_opendata/convenience.py
+++ b/packages/data/src/pyearthtools/data/download/ecmwf_opendata/convenience.py
@@ -16,6 +16,7 @@
 """Convenience classes for OpenData"""
 
 import functools
+
 from pyearthtools.data.download.ecmwf_opendata.opendata import OpenData
 
 

--- a/packages/data/src/pyearthtools/data/download/ecmwf_opendata/opendata.py
+++ b/packages/data/src/pyearthtools/data/download/ecmwf_opendata/opendata.py
@@ -20,7 +20,7 @@ from typing import Any, Literal
 
 import pyearthtools.data
 import xarray as xr
-from pyearthtools.data.download import DownloadIndex
+from pyearthtools.data.download.templates import DownloadIndex
 from pyearthtools.data.download.ecmwf_opendata import opendata_variables
 from pyearthtools.data.indexes import (
     VARIABLE_DEFAULT,
@@ -42,7 +42,7 @@ VARIABLES = [*opendata_variables.single, *opendata_variables.pressure, "all"]
 RENAME_DICT = {"t2m": "2t", "u10": "10u", "v10": "10v"}
 
 
-def rounder(time: pyearthtools.data.Petdt, round_value: int = 6) -> int:
+def rounder(time: pyearthtools.data.time.Petdt, round_value: int = 6) -> int:
     return (time.hour // round_value) * round_value
 
 
@@ -193,7 +193,7 @@ class OpenData(DownloadIndex):
         """Get the latest data from `ecwmf-opendata`"""
         return self(self._get_latest())
 
-    def download(self, querytime: str | pyearthtools.data.Petdt) -> xr.Dataset:
+    def download(self, querytime: str | pyearthtools.data.time.Petdt) -> xr.Dataset:
         """Download data from `ecwmf-opendata`"""
         if self._client is None:
             raise ImportError(f"`ecwmwf.opendata` was not imported, cannot download new data.")
@@ -201,8 +201,8 @@ class OpenData(DownloadIndex):
         if querytime == "l1atest":
             querytime = self._get_latest()
 
-        date = pyearthtools.data.Petdt(querytime).at_resolution("day")
-        time = rounder(pyearthtools.data.Petdt(querytime))
+        date = pyearthtools.data.time.Petdt(querytime).at_resolution("day")
+        time = rounder(pyearthtools.data.time.Petdt(querytime))
 
         request = dict(self._request_base)
         path = self.get_tempdir()

--- a/packages/data/src/pyearthtools/data/download/ecmwf_opendata/opendata.py
+++ b/packages/data/src/pyearthtools/data/download/ecmwf_opendata/opendata.py
@@ -20,8 +20,8 @@ from typing import Any, Literal
 
 import pyearthtools.data
 import xarray as xr
-from pyearthtools.data.download.templates import DownloadIndex
 from pyearthtools.data.download.ecmwf_opendata import opendata_variables
+from pyearthtools.data.download.templates import DownloadIndex
 from pyearthtools.data.indexes import (
     VARIABLE_DEFAULT,
     VariableDefault,

--- a/packages/data/src/pyearthtools/data/download/ecmwf_opendata/opendata.py
+++ b/packages/data/src/pyearthtools/data/download/ecmwf_opendata/opendata.py
@@ -15,21 +15,19 @@
 
 from __future__ import annotations
 
-from typing import Literal, Any
 import warnings
-import xarray as xr
+from typing import Any, Literal
 
 import pyearthtools.data
+import xarray as xr
+from pyearthtools.data.download import DownloadIndex
+from pyearthtools.data.download.ecmwf_opendata import opendata_variables
 from pyearthtools.data.indexes import (
+    VARIABLE_DEFAULT,
+    VariableDefault,
     alias_arguments,
     check_arguments,
-    VariableDefault,
-    VARIABLE_DEFAULT,
 )
-
-from pyearthtools.data.download.ecmwf_opendata import opendata_variables
-from pyearthtools.data.download import DownloadIndex
-
 
 VALID_MODELS = Literal["aifs", "ifs"]
 VALID_STREAM = Literal["oper", "enfo", "waef", "wave"]

--- a/packages/data/src/pyearthtools/data/download/templates.py
+++ b/packages/data/src/pyearthtools/data/download/templates.py
@@ -27,8 +27,9 @@ from tempfile import TemporaryDirectory
 from typing import Type
 
 import urllib3
-from pyearthtools.data import DataNotFoundError, IndexWarning
-from pyearthtools.data.indexes import CachingIndex
+from pyearthtools.data.exceptions import DataNotFoundError
+from pyearthtools.data.warnings import IndexWarning
+from pyearthtools.data.indexes.cacheIndex import CachingIndex
 from pyearthtools.data.patterns import PatternIndex
 
 

--- a/packages/data/src/pyearthtools/data/download/templates.py
+++ b/packages/data/src/pyearthtools/data/download/templates.py
@@ -18,19 +18,17 @@ Templates for Downloading data
 """
 
 from __future__ import annotations
-from abc import abstractmethod, ABCMeta
-from typing import Type
-import warnings
 
-from tempfile import TemporaryDirectory
+import functools
+import warnings
+from abc import ABCMeta, abstractmethod
 from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Type
 
 import urllib3
-import functools
-
+from pyearthtools.data import DataNotFoundError, IndexWarning
 from pyearthtools.data.indexes import CachingIndex
-from pyearthtools.data import IndexWarning, DataNotFoundError
-
 from pyearthtools.data.patterns import PatternIndex
 
 

--- a/packages/data/src/pyearthtools/data/download/templates.py
+++ b/packages/data/src/pyearthtools/data/download/templates.py
@@ -28,9 +28,9 @@ from typing import Type
 
 import urllib3
 from pyearthtools.data.exceptions import DataNotFoundError
-from pyearthtools.data.warnings import IndexWarning
 from pyearthtools.data.indexes.cacheIndex import CachingIndex
 from pyearthtools.data.patterns import PatternIndex
+from pyearthtools.data.warnings import IndexWarning
 
 
 @functools.lru_cache(None)

--- a/packages/data/src/pyearthtools/data/exceptions.py
+++ b/packages/data/src/pyearthtools/data/exceptions.py
@@ -18,9 +18,9 @@
 """
 
 from __future__ import annotations
-from typing import Any, Callable
 
 import warnings
+from typing import Any, Callable
 
 
 class InvalidIndexError(KeyError):

--- a/packages/data/src/pyearthtools/data/indexes/__init__.py
+++ b/packages/data/src/pyearthtools/data/indexes/__init__.py
@@ -114,42 +114,40 @@ classDiagram
 
 """
 
+from pyearthtools.data.indexes import decorators, utilities
+from pyearthtools.data.indexes.cacheIndex import (
+    CachingForecastIndex,
+    CachingIndex,
+    FileSystemCacheIndex,
+    FunctionalCacheIndex,
+    FunctionalMemCacheIndex,
+    MemCache,
+)
+from pyearthtools.data.indexes.decorators import alias_arguments, check_arguments
+from pyearthtools.data.indexes.extensions import register_accessor
+from pyearthtools.data.indexes.fake import FakeIndex
 from pyearthtools.data.indexes.indexes import (
-    Index,
-    DataIndex,
-    FileSystemIndex,
-    TimeIndex,
-    TimeDataIndex,
-    AdvancedTimeIndex,
     AdvancedTimeDataIndex,
+    AdvancedTimeIndex,
+    ArchiveIndex,
     BaseTimeIndex,
     DataFileSystemIndex,
-    ArchiveIndex,
+    DataIndex,
+    FileSystemIndex,
     ForecastIndex,
+    Index,
     StaticDataIndex,
+    TimeDataIndex,
+    TimeIndex,
 )
-from pyearthtools.data.indexes.cacheIndex import (
-    FileSystemCacheIndex,
-    CachingIndex,
-    CachingForecastIndex,
-    FunctionalCacheIndex,
-    MemCache,
-    FunctionalMemCacheIndex,
-)
-from pyearthtools.data.indexes import utilities, decorators
-from pyearthtools.data.indexes.extensions import register_accessor
-
-from pyearthtools.data.indexes.utilities.spellcheck import VariableDefault, VARIABLE_DEFAULT
-from pyearthtools.data.indexes.utilities.structure import structure
-
-from pyearthtools.data.indexes.decorators import alias_arguments, check_arguments
-
 from pyearthtools.data.indexes.intake import IntakeIndex, IntakeIndexCache
 from pyearthtools.data.indexes.templates import Structured
-
-from pyearthtools.data.indexes.fake import FakeIndex
-
 from pyearthtools.data.indexes.utilities.folder_size import ByteSize
+from pyearthtools.data.indexes.utilities.spellcheck import (
+    VARIABLE_DEFAULT,
+    VariableDefault,
+)
+from pyearthtools.data.indexes.utilities.structure import structure
 
 __all__ = [
     "Index",

--- a/packages/data/src/pyearthtools/data/indexes/cacheIndex.py
+++ b/packages/data/src/pyearthtools/data/indexes/cacheIndex.py
@@ -28,8 +28,10 @@ from typing import Any, Callable, Literal
 
 import pyearthtools.data
 import xarray as xr
-from pyearthtools.data import DataNotFoundError, TimeDelta, patterns
-from pyearthtools.data.indexes import (
+from pyearthtools.data.time import TimeDelta
+from pyearthtools.data.exceptions import DataNotFoundError
+from pyearthtools.data import patterns
+from pyearthtools.data.indexes.indexes import (
     ArchiveIndex,
     DataIndex,
     FileSystemIndex,

--- a/packages/data/src/pyearthtools/data/indexes/cacheIndex.py
+++ b/packages/data/src/pyearthtools/data/indexes/cacheIndex.py
@@ -28,9 +28,8 @@ from typing import Any, Callable, Literal
 
 import pyearthtools.data
 import xarray as xr
-from pyearthtools.data.time import TimeDelta
-from pyearthtools.data.exceptions import DataNotFoundError
 from pyearthtools.data import patterns
+from pyearthtools.data.exceptions import DataNotFoundError
 from pyearthtools.data.indexes.indexes import (
     ArchiveIndex,
     DataIndex,
@@ -45,6 +44,7 @@ from pyearthtools.data.indexes.utilities.delete_files import (
 )
 from pyearthtools.data.indexes.utilities.folder_size import ByteSize, FolderSize
 from pyearthtools.data.patterns.default import PatternIndex
+from pyearthtools.data.time import TimeDelta
 from pyearthtools.data.transforms import Transform, TransformCollection
 from pyearthtools.data.warnings import pyearthtoolsDataWarning
 from pyearthtools.utils.context import ChangeValue

--- a/packages/data/src/pyearthtools/data/indexes/cacheIndex.py
+++ b/packages/data/src/pyearthtools/data/indexes/cacheIndex.py
@@ -15,37 +15,36 @@
 
 from __future__ import annotations
 
+import logging
 import sys
+import time
+import warnings
 from abc import abstractmethod
 from functools import cached_property
-from pathlib import Path
-from typing import Any, Literal, Callable
-import warnings
-import logging
 from hashlib import sha512
-import time
 from multiprocessing import Process
-
-import xarray as xr
+from pathlib import Path
+from typing import Any, Callable, Literal
 
 import pyearthtools.data
-
-from pyearthtools.data import patterns, TimeDelta, DataNotFoundError
-from pyearthtools.data.transforms import Transform, TransformCollection
-from pyearthtools.data.patterns.default import PatternIndex
-from pyearthtools.data.warnings import pyearthtoolsDataWarning
-
+import xarray as xr
+from pyearthtools.data import DataNotFoundError, TimeDelta, patterns
 from pyearthtools.data.indexes import (
     ArchiveIndex,
+    DataIndex,
     FileSystemIndex,
     ForecastIndex,
-    TimeIndex,
-    DataIndex,
     Index,
+    TimeIndex,
 )
-from pyearthtools.data.indexes.utilities.delete_files import delete_older_than, delete_path
+from pyearthtools.data.indexes.utilities.delete_files import (
+    delete_older_than,
+    delete_path,
+)
 from pyearthtools.data.indexes.utilities.folder_size import ByteSize, FolderSize
-
+from pyearthtools.data.patterns.default import PatternIndex
+from pyearthtools.data.transforms import Transform, TransformCollection
+from pyearthtools.data.warnings import pyearthtoolsDataWarning
 from pyearthtools.utils.context import ChangeValue
 
 LOG = logging.getLogger("pyearthtools.data")

--- a/packages/data/src/pyearthtools/data/indexes/combine.py
+++ b/packages/data/src/pyearthtools/data/indexes/combine.py
@@ -16,10 +16,8 @@
 from __future__ import annotations
 
 import xarray as xr
-
-
-from pyearthtools.data.indexes import Index, AdvancedTimeDataIndex
 from pyearthtools.data import Petdt
+from pyearthtools.data.indexes import AdvancedTimeDataIndex, Index
 from pyearthtools.data.operations import SpatialInterpolation, TemporalInterpolation
 from pyearthtools.data.transforms.transform import Transform, TransformCollection
 

--- a/packages/data/src/pyearthtools/data/indexes/decorators.py
+++ b/packages/data/src/pyearthtools/data/indexes/decorators.py
@@ -20,16 +20,14 @@ Decorators for use by `pyearthtools.data.indexes`
 from __future__ import annotations
 
 import functools
-import warnings
-
 import inspect
+import warnings
 from pathlib import Path
 from typing import Any
 
-from pyearthtools.data.indexes.utilities import spellcheck, open_static
-from pyearthtools.utils.decorators import alias_arguments
-
+from pyearthtools.data.indexes.utilities import open_static, spellcheck
 from pyearthtools.data.modifications import variable_modifications
+from pyearthtools.utils.decorators import alias_arguments
 
 __all__ = [
     "alias_arguments",

--- a/packages/data/src/pyearthtools/data/indexes/fake.py
+++ b/packages/data/src/pyearthtools/data/indexes/fake.py
@@ -15,13 +15,11 @@
 
 from __future__ import annotations
 
-import xarray as xr
 import numpy as np
-
-from pyearthtools.data.time import Petdt
-from pyearthtools.data.indexes.indexes import AdvancedTimeDataIndex
-
+import xarray as xr
 from pyearthtools.data.indexes.decorators import variable_modifications
+from pyearthtools.data.indexes.indexes import AdvancedTimeDataIndex
+from pyearthtools.data.time import Petdt
 
 
 class FakeIndex(AdvancedTimeDataIndex):

--- a/packages/data/src/pyearthtools/data/indexes/indexes.py
+++ b/packages/data/src/pyearthtools/data/indexes/indexes.py
@@ -28,39 +28,32 @@ See [here][pyearthtools.data.indexes] for details.
 
 from __future__ import annotations
 
-import warnings
 import datetime
 import functools
 import logging
-from abc import abstractmethod, ABCMeta
-
+import warnings
+from abc import ABCMeta, abstractmethod
 from pathlib import Path
 from typing import Any, Callable, Iterable, Literal, Optional
 
-import xarray as xr
-
 import pyearthtools.data
 import pyearthtools.utils
-
-from pyearthtools.data.time import Petdt, TimeDelta, TimeRange
-
-from pyearthtools.data.transforms.transform import (
-    Transform,
-    TransformCollection,
-    FunctionTransform,
-)
-
-from pyearthtools.data.warnings import IndexWarning
-from pyearthtools.data.exceptions import DataNotFoundError
-from pyearthtools.data.operations import index_routines, index_operations, forecast_op
+import xarray as xr
 from pyearthtools.data import operations
-
+from pyearthtools.data.exceptions import DataNotFoundError
+from pyearthtools.data.indexes.utilities import dimensions, open_files
 from pyearthtools.data.indexes.utilities.mixins import (
     CallRedirectMixin,
     CatalogMixin,
 )
-from pyearthtools.data.indexes.utilities import open_files, dimensions
-
+from pyearthtools.data.operations import forecast_op, index_operations, index_routines
+from pyearthtools.data.time import Petdt, TimeDelta, TimeRange
+from pyearthtools.data.transforms.transform import (
+    FunctionTransform,
+    Transform,
+    TransformCollection,
+)
+from pyearthtools.data.warnings import IndexWarning
 from pyearthtools.utils.context import ChangeValue
 
 LOG = logging.getLogger("pyearthtools.data")

--- a/packages/data/src/pyearthtools/data/indexes/intake.py
+++ b/packages/data/src/pyearthtools/data/indexes/intake.py
@@ -19,19 +19,17 @@ Intake - ESM Index
 
 from __future__ import annotations
 
+import functools
+import logging
 from pathlib import Path
 from typing import Any, Callable
 
 import xarray as xr
-import logging
-import functools
-
-from pyearthtools.data.indexes.indexes import DataIndex
 from pyearthtools.data.indexes.cacheIndex import FileSystemCacheIndex
-from pyearthtools.data.transforms import Transform, TransformCollection
-from pyearthtools.data.patterns.argument import flattened_combinations
-
+from pyearthtools.data.indexes.indexes import DataIndex
 from pyearthtools.data.indexes.utilities.delete_files import delete_path
+from pyearthtools.data.patterns.argument import flattened_combinations
+from pyearthtools.data.transforms import Transform, TransformCollection
 
 LOG = logging.getLogger("pyearthtools.data")
 

--- a/packages/data/src/pyearthtools/data/indexes/templates/structured.py
+++ b/packages/data/src/pyearthtools/data/indexes/templates/structured.py
@@ -18,11 +18,15 @@ Template for structured data
 """
 
 from __future__ import annotations
+
 from pathlib import Path
 
 from pyearthtools.data import Petdt
 from pyearthtools.data.indexes import ArchiveIndex, decorators
-from pyearthtools.data.indexes.utilities.spellcheck import VARIABLE_DEFAULT, VariableDefault
+from pyearthtools.data.indexes.utilities.spellcheck import (
+    VARIABLE_DEFAULT,
+    VariableDefault,
+)
 from pyearthtools.data.transforms import Transform, TransformCollection
 
 

--- a/packages/data/src/pyearthtools/data/indexes/templates/structured.py
+++ b/packages/data/src/pyearthtools/data/indexes/templates/structured.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from pyearthtools.data import Petdt
+from pyearthtools.data.time import Petdt
 from pyearthtools.data.indexes import ArchiveIndex, decorators
 from pyearthtools.data.indexes.utilities.spellcheck import (
     VARIABLE_DEFAULT,

--- a/packages/data/src/pyearthtools/data/indexes/templates/structured.py
+++ b/packages/data/src/pyearthtools/data/indexes/templates/structured.py
@@ -21,12 +21,12 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from pyearthtools.data.time import Petdt
 from pyearthtools.data.indexes import ArchiveIndex, decorators
 from pyearthtools.data.indexes.utilities.spellcheck import (
     VARIABLE_DEFAULT,
     VariableDefault,
 )
+from pyearthtools.data.time import Petdt
 from pyearthtools.data.transforms import Transform, TransformCollection
 
 

--- a/packages/data/src/pyearthtools/data/indexes/utilities/__init__.py
+++ b/packages/data/src/pyearthtools/data/indexes/utilities/__init__.py
@@ -17,6 +17,6 @@
 Various utilites for `pyearthtools.data.indexes`
 """
 
-from pyearthtools.data.indexes.utilities import mixins, delete_files
+from pyearthtools.data.indexes.utilities import delete_files, mixins
 from pyearthtools.data.indexes.utilities.fileload import open_files, open_static
 from pyearthtools.data.indexes.utilities.spellcheck import check_prompt

--- a/packages/data/src/pyearthtools/data/indexes/utilities/delete_files.py
+++ b/packages/data/src/pyearthtools/data/indexes/utilities/delete_files.py
@@ -19,12 +19,12 @@ Utilities to delete files
 
 from __future__ import annotations
 
+import logging
 import os
-from pathlib import Path
 import shutil
 import time
+from pathlib import Path
 from typing import Literal, Sequence
-import logging
 
 from pyearthtools.data import TimeDelta
 from pyearthtools.utils.context import Catch

--- a/packages/data/src/pyearthtools/data/indexes/utilities/delete_files.py
+++ b/packages/data/src/pyearthtools/data/indexes/utilities/delete_files.py
@@ -26,7 +26,7 @@ import time
 from pathlib import Path
 from typing import Literal, Sequence
 
-from pyearthtools.data import TimeDelta
+from pyearthtools.data.time import TimeDelta
 from pyearthtools.utils.context import Catch
 
 LOG = logging.getLogger("pyearthtools.data")

--- a/packages/data/src/pyearthtools/data/indexes/utilities/dimensions.py
+++ b/packages/data/src/pyearthtools/data/indexes/utilities/dimensions.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from __future__ import annotations
+
 from typing import Hashable
 
 import xarray as xr

--- a/packages/data/src/pyearthtools/data/indexes/utilities/fileload.py
+++ b/packages/data/src/pyearthtools/data/indexes/utilities/fileload.py
@@ -14,21 +14,19 @@
 
 
 from __future__ import annotations
+
+import copy
 import json
 import os
+from importlib.resources import as_file, files
+from pathlib import Path
 from typing import Any, Callable
 
-import xarray as xr
 import numpy as np
 import pandas as pd
-
-from pathlib import Path
-from importlib.resources import files, as_file
-import yaml
-import copy
-
-
 import pyearthtools.utils
+import xarray as xr
+import yaml
 
 pyearthtools_CATALOG_EXTENSIONS = [".cat", ".catalog"]
 BLACKLISTED_EXTENSIONS = []

--- a/packages/data/src/pyearthtools/data/indexes/utilities/folder_size.py
+++ b/packages/data/src/pyearthtools/data/indexes/utilities/folder_size.py
@@ -21,14 +21,15 @@
 #
 
 from __future__ import annotations
-import os
 
-from typing import Literal, Sequence
-from pathlib import Path
 import functools
-import yaml
+import os
 import re
 import time
+from pathlib import Path
+from typing import Literal, Sequence
+
+import yaml
 
 
 @functools.total_ordering

--- a/packages/data/src/pyearthtools/data/indexes/utilities/mixins/__init__.py
+++ b/packages/data/src/pyearthtools/data/indexes/utilities/mixins/__init__.py
@@ -18,6 +18,6 @@ Mixins to add functionality to `pyearthtools.data.indexes`
 
 """
 
-from pyearthtools.data.indexes.utilities.mixins.index_repr import reprMixin
 from pyearthtools.data.indexes.utilities.mixins.call_redirect import CallRedirectMixin
 from pyearthtools.data.indexes.utilities.mixins.catalogs import CatalogMixin
+from pyearthtools.data.indexes.utilities.mixins.index_repr import reprMixin

--- a/packages/data/src/pyearthtools/data/indexes/utilities/mixins/catalogs.py
+++ b/packages/data/src/pyearthtools/data/indexes/utilities/mixins/catalogs.py
@@ -16,12 +16,10 @@
 from __future__ import annotations
 
 import warnings
-
 from pathlib import Path
 
-from pyearthtools.utils import initialisation
 from pyearthtools.data.utils import parse_path
-
+from pyearthtools.utils import initialisation
 
 SUFFIX = "edi"
 

--- a/packages/data/src/pyearthtools/data/indexes/utilities/mixins/index_repr.py
+++ b/packages/data/src/pyearthtools/data/indexes/utilities/mixins/index_repr.py
@@ -21,9 +21,7 @@ try:
 except ImportError:
     UTILS_REPR = False
 
-import pyearthtools.data
 import pyearthtools.data.catalog
-
 
 class reprMixin:
     def __get_steps_for_repr(self):

--- a/packages/data/src/pyearthtools/data/indexes/utilities/mixins/index_repr.py
+++ b/packages/data/src/pyearthtools/data/indexes/utilities/mixins/index_repr.py
@@ -23,6 +23,7 @@ except ImportError:
 
 import pyearthtools.data.catalog
 
+
 class reprMixin:
     def __get_steps_for_repr(self):
         class Information:

--- a/packages/data/src/pyearthtools/data/indexes/utilities/spellcheck.py
+++ b/packages/data/src/pyearthtools/data/indexes/utilities/spellcheck.py
@@ -18,6 +18,7 @@ Index spell checking
 """
 
 from __future__ import annotations
+
 from typing import Any, Type
 
 from pyearthtools.data.exceptions import InvalidIndexError

--- a/packages/data/src/pyearthtools/data/indexes/utilities/structure.py
+++ b/packages/data/src/pyearthtools/data/indexes/utilities/structure.py
@@ -1,3 +1,4 @@
+
 # Copyright Commonwealth of Australia, Bureau of Meteorology 2024.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/data/src/pyearthtools/data/indexes/utilities/structure.py
+++ b/packages/data/src/pyearthtools/data/indexes/utilities/structure.py
@@ -15,8 +15,8 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 import os
+from pathlib import Path
 from typing import Any
 
 import tqdm.auto as tqdm

--- a/packages/data/src/pyearthtools/data/indexes/utilities/structure.py
+++ b/packages/data/src/pyearthtools/data/indexes/utilities/structure.py
@@ -1,4 +1,3 @@
-
 # Copyright Commonwealth of Australia, Bureau of Meteorology 2024.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/data/src/pyearthtools/data/load.py
+++ b/packages/data/src/pyearthtools/data/load.py
@@ -15,17 +15,14 @@
 
 """Saving and Loading of `Indexes`"""
 
+import os
+from pathlib import Path
 from typing import Union
 
-from pathlib import Path
-import os
-
-import yaml
-
-from pyearthtools.utils import initialisation
-
 import pyearthtools.data
+import yaml
 from pyearthtools.data.utils import parse_path
+from pyearthtools.utils import initialisation
 
 CONFIG_KEY = "--CONFIG--"
 

--- a/packages/data/src/pyearthtools/data/modifications/__init__.py
+++ b/packages/data/src/pyearthtools/data/modifications/__init__.py
@@ -108,12 +108,9 @@ a dataset to be returned with the variable as modified but all timesteps as defi
 """
 
 
-from pyearthtools.data.modifications.modification import Modification
-
-from pyearthtools.data.modifications.register import register_modification
+from pyearthtools.data.modifications import aggregations, constants, reductions
 from pyearthtools.data.modifications.decorator import variable_modifications
-
-from pyearthtools.data.modifications import aggregations, reductions, constants
-
+from pyearthtools.data.modifications.modification import Modification
+from pyearthtools.data.modifications.register import register_modification
 
 __all__ = ["register_modification", "variable_modifications", "Modification"]

--- a/packages/data/src/pyearthtools/data/modifications/aggregations.py
+++ b/packages/data/src/pyearthtools/data/modifications/aggregations.py
@@ -20,12 +20,11 @@ Aggregation based `Modification's`
 from __future__ import annotations
 
 from typing import Literal
+
 import xarray as xr
-
-from pyearthtools.data.time import Petdt, TimeDelta, TimeResolution, TimeRange
 from pyearthtools.data.indexes.utilities.dimensions import identify_time_dimension
-
 from pyearthtools.data.modifications import Modification, register_modification
+from pyearthtools.data.time import Petdt, TimeDelta, TimeRange, TimeResolution
 
 
 class Aggregation(Modification):

--- a/packages/data/src/pyearthtools/data/modifications/aggregations.py
+++ b/packages/data/src/pyearthtools/data/modifications/aggregations.py
@@ -23,7 +23,8 @@ from typing import Literal
 
 import xarray as xr
 from pyearthtools.data.indexes.utilities.dimensions import identify_time_dimension
-from pyearthtools.data.modifications import Modification, register_modification
+from pyearthtools.data.modifications.modification import Modification
+from pyearthtools.data.modifications.register import register_modification
 from pyearthtools.data.time import Petdt, TimeDelta, TimeRange, TimeResolution
 
 

--- a/packages/data/src/pyearthtools/data/modifications/constants.py
+++ b/packages/data/src/pyearthtools/data/modifications/constants.py
@@ -20,12 +20,11 @@ Aggregation based `Modification's`
 from __future__ import annotations
 
 from typing import Optional, Union
+
 import xarray as xr
-
-from pyearthtools.data.time import Petdt, TimeRange
 from pyearthtools.data.indexes.utilities.dimensions import identify_time_dimension
-
 from pyearthtools.data.modifications import Modification, register_modification
+from pyearthtools.data.time import Petdt, TimeRange
 
 
 @register_modification("constant")

--- a/packages/data/src/pyearthtools/data/modifications/constants.py
+++ b/packages/data/src/pyearthtools/data/modifications/constants.py
@@ -23,7 +23,8 @@ from typing import Optional, Union
 
 import xarray as xr
 from pyearthtools.data.indexes.utilities.dimensions import identify_time_dimension
-from pyearthtools.data.modifications import Modification, register_modification
+from pyearthtools.data.modifications.modification import Modification
+from pyearthtools.data.modifications.register import register_modification
 from pyearthtools.data.time import Petdt, TimeRange
 
 

--- a/packages/data/src/pyearthtools/data/modifications/decorator.py
+++ b/packages/data/src/pyearthtools/data/modifications/decorator.py
@@ -26,7 +26,7 @@ import re
 from typing import Any, Callable, Optional, Type, Union
 
 import xarray as xr
-from pyearthtools.data.indexes import TimeDataIndex
+from pyearthtools.data.indexes.indexes import TimeDataIndex
 from pyearthtools.data.modifications.modification import Modification
 from pyearthtools.data.modifications.register import MODIFICATION_DICT
 from pyearthtools.data.transforms.transform import Transform

--- a/packages/data/src/pyearthtools/data/modifications/decorator.py
+++ b/packages/data/src/pyearthtools/data/modifications/decorator.py
@@ -19,21 +19,17 @@ Variable Modification decorator
 
 from __future__ import annotations
 
-import inspect
-import re
-import json
-
 import functools
-from typing import Callable, Any, Optional, Type, Union
+import inspect
+import json
+import re
+from typing import Any, Callable, Optional, Type, Union
+
 import xarray as xr
-
 from pyearthtools.data.indexes import TimeDataIndex
-
-from pyearthtools.data.transforms.transform import Transform
 from pyearthtools.data.modifications.modification import Modification
-
 from pyearthtools.data.modifications.register import MODIFICATION_DICT
-
+from pyearthtools.data.transforms.transform import Transform
 
 __all__ = ["variable_modifications", "Modification"]
 

--- a/packages/data/src/pyearthtools/data/modifications/modification.py
+++ b/packages/data/src/pyearthtools/data/modifications/modification.py
@@ -24,7 +24,8 @@ from typing import Any, Union
 
 import pyearthtools.data
 import xarray as xr
-from pyearthtools.data.indexes import TimeDataIndex
+import pyearthtools.data.indexes.indexes
+from pyearthtools.data.indexes.indexes import TimeDataIndex
 from pyearthtools.data.indexes.utilities.dimensions import identify_time_dimension
 from pyearthtools.data.transforms.transform import TransformCollection
 

--- a/packages/data/src/pyearthtools/data/modifications/modification.py
+++ b/packages/data/src/pyearthtools/data/modifications/modification.py
@@ -20,14 +20,12 @@ Base Class for Modification's
 from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
-
 from typing import Any, Union
-import xarray as xr
 
 import pyearthtools.data
+import xarray as xr
 from pyearthtools.data.indexes import TimeDataIndex
 from pyearthtools.data.indexes.utilities.dimensions import identify_time_dimension
-
 from pyearthtools.data.transforms.transform import TransformCollection
 
 

--- a/packages/data/src/pyearthtools/data/modifications/modification.py
+++ b/packages/data/src/pyearthtools/data/modifications/modification.py
@@ -23,8 +23,8 @@ from abc import ABCMeta, abstractmethod
 from typing import Any, Union
 
 import pyearthtools.data
-import xarray as xr
 import pyearthtools.data.indexes.indexes
+import xarray as xr
 from pyearthtools.data.indexes.indexes import TimeDataIndex
 from pyearthtools.data.indexes.utilities.dimensions import identify_time_dimension
 from pyearthtools.data.transforms.transform import TransformCollection

--- a/packages/data/src/pyearthtools/data/modifications/reductions.py
+++ b/packages/data/src/pyearthtools/data/modifications/reductions.py
@@ -20,12 +20,11 @@ Reduction based `Modification's`
 from __future__ import annotations
 
 from typing import Union
+
 import xarray as xr
-
-from pyearthtools.data.time import Petdt, TimeDelta, TimeResolution
 from pyearthtools.data.indexes.utilities.dimensions import identify_time_dimension
-
 from pyearthtools.data.modifications import Modification, register_modification
+from pyearthtools.data.time import Petdt, TimeDelta, TimeResolution
 
 
 class Reduction(Modification):

--- a/packages/data/src/pyearthtools/data/modifications/reductions.py
+++ b/packages/data/src/pyearthtools/data/modifications/reductions.py
@@ -23,7 +23,8 @@ from typing import Union
 
 import xarray as xr
 from pyearthtools.data.indexes.utilities.dimensions import identify_time_dimension
-from pyearthtools.data.modifications import Modification, register_modification
+from pyearthtools.data.modifications.modification import Modification
+from pyearthtools.data.modifications.register import register_modification
 from pyearthtools.data.time import Petdt, TimeDelta, TimeResolution
 
 

--- a/packages/data/src/pyearthtools/data/modifications/register.py
+++ b/packages/data/src/pyearthtools/data/modifications/register.py
@@ -19,8 +19,8 @@ Register Modifications
 
 from __future__ import annotations
 
-from typing import Callable, Any, Type
 import warnings
+from typing import Any, Callable, Type
 
 import pyearthtools.data
 

--- a/packages/data/src/pyearthtools/data/operations/__init__.py
+++ b/packages/data/src/pyearthtools/data/operations/__init__.py
@@ -32,13 +32,13 @@ Useful Data Operations to apply to [indexes][pyearthtools.data.indexes] or [Data
 """
 
 from pyearthtools.data.operations import interpolation
-from pyearthtools.data.operations.interpolation import (
-    SpatialInterpolation,
-    TemporalInterpolation,
-    FullInterpolation,
-)
-from pyearthtools.data.operations.percentile import percentile
 from pyearthtools.data.operations.aggregation import aggregation
 from pyearthtools.data.operations.binning import binning
+from pyearthtools.data.operations.interpolation import (
+    FullInterpolation,
+    SpatialInterpolation,
+    TemporalInterpolation,
+)
+from pyearthtools.data.operations.percentile import percentile
 
 # from pyearthtools.data.operations.index_routines import safe_series, series

--- a/packages/data/src/pyearthtools/data/operations/aggregation.py
+++ b/packages/data/src/pyearthtools/data/operations/aggregation.py
@@ -16,8 +16,8 @@
 from __future__ import annotations
 
 from typing import Callable
-import xarray as xr
 
+import xarray as xr
 from pyearthtools.data.transforms import aggregation as aggr_trans
 
 

--- a/packages/data/src/pyearthtools/data/operations/binning.py
+++ b/packages/data/src/pyearthtools/data/operations/binning.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 from typing import Literal
 
 import xarray as xr
-from pyearthtools.data import TimeDelta
+from pyearthtools.data.time import TimeDelta
 
 BINNING_SETUP = {  # Base Binning setup
     "seasonal": [

--- a/packages/data/src/pyearthtools/data/operations/binning.py
+++ b/packages/data/src/pyearthtools/data/operations/binning.py
@@ -19,11 +19,10 @@ Binning of datasets by dimension and predefined configurations.
 
 from __future__ import annotations
 
-import xarray as xr
 from typing import Literal
 
+import xarray as xr
 from pyearthtools.data import TimeDelta
-
 
 BINNING_SETUP = {  # Base Binning setup
     "seasonal": [

--- a/packages/data/src/pyearthtools/data/operations/forecast_op.py
+++ b/packages/data/src/pyearthtools/data/operations/forecast_op.py
@@ -15,17 +15,17 @@
 
 from __future__ import annotations
 
-
 import xarray as xr
-
-
-from pyearthtools.data.exceptions import DataNotFoundError, InvalidIndexError, InvalidDataError
+from pyearthtools.data.exceptions import (
+    DataNotFoundError,
+    InvalidDataError,
+    InvalidIndexError,
+)
+from pyearthtools.data.operations import index_routines
+from pyearthtools.data.operations.utils import identify_time_dimension
 from pyearthtools.data.time import Petdt, TimeDelta, TimeRange
 from pyearthtools.data.transforms.transform import Transform, TransformCollection
 from pyearthtools.data.warnings import IndexWarning
-
-from pyearthtools.data.operations import index_routines
-from pyearthtools.data.operations.utils import identify_time_dimension
 
 
 def forecast_series(

--- a/packages/data/src/pyearthtools/data/operations/index_operations.py
+++ b/packages/data/src/pyearthtools/data/operations/index_operations.py
@@ -19,25 +19,23 @@ Provide common operations to be applied to [DataIndexes][pyearthtools.data.DataI
 
 from __future__ import annotations
 
-import datetime
 import builtins
+import datetime
 import os
 from pathlib import Path
 from typing import Callable, Union
 
 import numpy as np
-from tqdm.auto import tqdm, trange
-import xarray as xr
-
 import pyearthtools.data
-
-from pyearthtools.data.time import Petdt, TimeDelta
+import xarray as xr
 from pyearthtools.data.exceptions import (
     DataNotFoundError,
     InvalidIndexError,
     run_and_catch_exception,
 )
+from pyearthtools.data.time import Petdt, TimeDelta
 from pyearthtools.data.transforms import Transform, TransformCollection
+from tqdm.auto import tqdm, trange
 
 
 def split_ds(dataset: xr.Dataset, divisions: int = 1, dim: str = "time") -> list[xr.Dataset]:

--- a/packages/data/src/pyearthtools/data/operations/index_routines.py
+++ b/packages/data/src/pyearthtools/data/operations/index_routines.py
@@ -17,25 +17,24 @@ from __future__ import annotations
 
 import functools
 import logging
-from typing import Iterable
-
 import warnings
+from typing import Iterable
 
 import numpy as np
 import pandas as pd
-import xarray as xr
-
 import pyearthtools
-
 import pyearthtools.data
 import pyearthtools.utils
-
-from pyearthtools.data.exceptions import DataNotFoundError, InvalidIndexError, InvalidDataError
-from pyearthtools.data.time import Petdt, TimeDelta, time_delta_resolution, TimeRange
+import xarray as xr
+from pyearthtools.data.exceptions import (
+    DataNotFoundError,
+    InvalidDataError,
+    InvalidIndexError,
+)
+from pyearthtools.data.operations.utils import identify_time_dimension
+from pyearthtools.data.time import Petdt, TimeDelta, TimeRange, time_delta_resolution
 from pyearthtools.data.transforms.transform import Transform, TransformCollection
 from pyearthtools.data.warnings import IndexWarning
-from pyearthtools.data.operations.utils import identify_time_dimension
-
 
 LOG = logging.getLogger("pyearthtools.data")
 

--- a/packages/data/src/pyearthtools/data/operations/interpolation.py
+++ b/packages/data/src/pyearthtools/data/operations/interpolation.py
@@ -22,10 +22,8 @@ from __future__ import annotations
 from typing import Callable
 
 import numpy as np
-import xarray as xr
-
-
 import pyearthtools.data
+import xarray as xr
 from pyearthtools.data.transforms import interpolation as interp
 
 

--- a/packages/data/src/pyearthtools/data/operations/utils.py
+++ b/packages/data/src/pyearthtools/data/operations/utils.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from typing import Hashable
 
 import xarray as xr

--- a/packages/data/src/pyearthtools/data/patterns/__init__.py
+++ b/packages/data/src/pyearthtools/data/patterns/__init__.py
@@ -52,41 +52,38 @@ str(pattern.search('test','arg'))
 """
 
 from pyearthtools.data.patterns import utils
-
-from pyearthtools.data.patterns.default import (
-    PatternIndex,
-    PatternTimeIndex,
-    PatternForecastIndex,
-    PatternVariableAware,
-)
-
 from pyearthtools.data.patterns.argument import (
     Argument,
     ArgumentExpansion,
-    ArgumentExpansionVariable,
     ArgumentExpansionFactory,
+    ArgumentExpansionVariable,
+)
+from pyearthtools.data.patterns.default import (
+    PatternForecastIndex,
+    PatternIndex,
+    PatternTimeIndex,
+    PatternVariableAware,
 )
 from pyearthtools.data.patterns.direct import (
     Direct,
-    TemporalDirect,
-    ForecastDirect,
-    DirectVariable,
-    ForecastDirectVariable,
-    TemporalDirectVariable,
     DirectFactory,
+    DirectVariable,
+    ForecastDirect,
+    ForecastDirectVariable,
+    TemporalDirect,
+    TemporalDirectVariable,
 )
 from pyearthtools.data.patterns.expanded_date import (
     ExpandedDate,
-    TemporalExpandedDate,
-    ForecastExpandedDate,
-    ExpandedDateVariable,
-    ForecastExpandedDateVariable,
-    TemporalExpandedDateVariable,
     ExpandedDateFactory,
+    ExpandedDateVariable,
+    ForecastExpandedDate,
+    ForecastExpandedDateVariable,
+    TemporalExpandedDate,
+    TemporalExpandedDateVariable,
 )
-from pyearthtools.data.patterns.static import Static
 from pyearthtools.data.patterns.parser import ParsingPattern
-
+from pyearthtools.data.patterns.static import Static
 
 ZARR_IMPORTED = True
 try:

--- a/packages/data/src/pyearthtools/data/patterns/argument.py
+++ b/packages/data/src/pyearthtools/data/patterns/argument.py
@@ -18,11 +18,10 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Iterable
 
-from pyearthtools.data.patterns import PatternIndex, PatternVariableAware
+import pyearthtools.utils
 from pyearthtools.data.indexes import decorators
 from pyearthtools.data.indexes.utilities import spellcheck
-
-import pyearthtools.utils
+from pyearthtools.data.patterns import PatternIndex, PatternVariableAware
 from pyearthtools.utils.decorators import classproperty
 
 """

--- a/packages/data/src/pyearthtools/data/patterns/argument.py
+++ b/packages/data/src/pyearthtools/data/patterns/argument.py
@@ -21,14 +21,19 @@ from typing import Any, Iterable
 import pyearthtools.utils
 from pyearthtools.data.indexes import decorators
 from pyearthtools.data.indexes.utilities import spellcheck
-from pyearthtools.data.patterns import PatternIndex, PatternVariableAware
+from pyearthtools.data.patterns.default import PatternIndex, PatternVariableAware
 from pyearthtools.utils.decorators import classproperty
 
 """
 Generate FilePath Structure based upon expansion of arguments
 """
 
-DEFAULT_EXTENSION = pyearthtools.utils.config.get("data.patterns.default_extension")
+import pyearthtools.data.logger  # Initialise data logger
+
+try:
+    DEFAULT_EXTENSION = pyearthtools.utils.config.get("data.patterns.default_extension")
+except:
+    DEFAULT_EXTENSION = ".nc"
 
 
 def flattened_combinations(iterable: Iterable[Any | Iterable[Any]], r: int = 1) -> list[Any | list[Any]]:

--- a/packages/data/src/pyearthtools/data/patterns/default.py
+++ b/packages/data/src/pyearthtools/data/patterns/default.py
@@ -24,13 +24,13 @@ from typing import Any, Callable
 import xarray as xr
 from pyearthtools.data import patterns
 from pyearthtools.data.exceptions import DataNotFoundError
-from pyearthtools.data.indexes import (
+from pyearthtools.data.indexes.indexes import (
     AdvancedTimeIndex,
     DataIndex,
     FileSystemIndex,
     ForecastIndex,
-    decorators,
 )
+from pyearthtools.data.indexes import decorators
 from pyearthtools.data.save import save
 from pyearthtools.data.warnings import pyearthtoolsDataWarning
 

--- a/packages/data/src/pyearthtools/data/patterns/default.py
+++ b/packages/data/src/pyearthtools/data/patterns/default.py
@@ -24,13 +24,13 @@ from typing import Any, Callable
 import xarray as xr
 from pyearthtools.data import patterns
 from pyearthtools.data.exceptions import DataNotFoundError
+from pyearthtools.data.indexes import decorators
 from pyearthtools.data.indexes.indexes import (
     AdvancedTimeIndex,
     DataIndex,
     FileSystemIndex,
     ForecastIndex,
 )
-from pyearthtools.data.indexes import decorators
 from pyearthtools.data.save import save
 from pyearthtools.data.warnings import pyearthtoolsDataWarning
 

--- a/packages/data/src/pyearthtools/data/patterns/default.py
+++ b/packages/data/src/pyearthtools/data/patterns/default.py
@@ -14,26 +14,25 @@
 
 
 from __future__ import annotations
-from abc import abstractmethod
 
 import os
+import warnings
+from abc import abstractmethod
 from pathlib import Path
 from typing import Any, Callable
-import warnings
 
 import xarray as xr
-
 from pyearthtools.data import patterns
 from pyearthtools.data.exceptions import DataNotFoundError
-from pyearthtools.data.warnings import pyearthtoolsDataWarning
 from pyearthtools.data.indexes import (
+    AdvancedTimeIndex,
     DataIndex,
     FileSystemIndex,
-    AdvancedTimeIndex,
     ForecastIndex,
     decorators,
 )
 from pyearthtools.data.save import save
+from pyearthtools.data.warnings import pyearthtoolsDataWarning
 
 
 class PatternIndex(DataIndex, FileSystemIndex):

--- a/packages/data/src/pyearthtools/data/patterns/direct.py
+++ b/packages/data/src/pyearthtools/data/patterns/direct.py
@@ -27,8 +27,8 @@ from pathlib import Path
 from typing import Any
 
 import pyearthtools.utils
-from pyearthtools.data.indexes.indexes import TimeIndex
 from pyearthtools.data.indexes import decorators
+from pyearthtools.data.indexes.indexes import TimeIndex
 from pyearthtools.data.patterns import (
     PatternForecastIndex,
     PatternIndex,
@@ -42,10 +42,11 @@ DIRECTORY_PATTERN = "{ROOT_DIR}/{FILE}"
 FILE_PATTERN = "{prefix}{time}{extension}"
 
 import pyearthtools.data.logger
+
 try:
     DEFAULT_EXTENSION = pyearthtools.utils.config.get("data.patterns.default_extension")
 except:
-    DEFAULT_EXTENSION = ".nc" 
+    DEFAULT_EXTENSION = ".nc"
 
 
 def nonNone(*args):

--- a/packages/data/src/pyearthtools/data/patterns/direct.py
+++ b/packages/data/src/pyearthtools/data/patterns/direct.py
@@ -27,7 +27,8 @@ from pathlib import Path
 from typing import Any
 
 import pyearthtools.utils
-from pyearthtools.data.indexes import TimeIndex, decorators
+from pyearthtools.data.indexes.indexes import TimeIndex
+from pyearthtools.data.indexes import decorators
 from pyearthtools.data.patterns import (
     PatternForecastIndex,
     PatternIndex,
@@ -39,7 +40,12 @@ from pyearthtools.utils.decorators import classproperty
 
 DIRECTORY_PATTERN = "{ROOT_DIR}/{FILE}"
 FILE_PATTERN = "{prefix}{time}{extension}"
-DEFAULT_EXTENSION = pyearthtools.utils.config.get("data.patterns.default_extension")
+
+import pyearthtools.data.logger
+try:
+    DEFAULT_EXTENSION = pyearthtools.utils.config.get("data.patterns.default_extension")
+except:
+    DEFAULT_EXTENSION = ".nc" 
 
 
 def nonNone(*args):

--- a/packages/data/src/pyearthtools/data/patterns/direct.py
+++ b/packages/data/src/pyearthtools/data/patterns/direct.py
@@ -26,16 +26,15 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from pyearthtools.data.time import Petdt, TimeResolution
+import pyearthtools.utils
+from pyearthtools.data.indexes import TimeIndex, decorators
 from pyearthtools.data.patterns import (
+    PatternForecastIndex,
     PatternIndex,
     PatternTimeIndex,
     PatternVariableAware,
-    PatternForecastIndex,
 )
-from pyearthtools.data.indexes import TimeIndex, decorators
-
-import pyearthtools.utils
+from pyearthtools.data.time import Petdt, TimeResolution
 from pyearthtools.utils.decorators import classproperty
 
 DIRECTORY_PATTERN = "{ROOT_DIR}/{FILE}"

--- a/packages/data/src/pyearthtools/data/patterns/expanded_date.py
+++ b/packages/data/src/pyearthtools/data/patterns/expanded_date.py
@@ -26,7 +26,6 @@ from pathlib import Path
 from typing import Any
 
 import pyearthtools.utils
-from pyearthtools.data.time import Petdt, TimeResolution
 from pyearthtools.data.indexes import decorators
 from pyearthtools.data.patterns.default import (
     PatternForecastIndex,
@@ -34,16 +33,18 @@ from pyearthtools.data.patterns.default import (
     PatternTimeIndex,
     PatternVariableAware,
 )
+from pyearthtools.data.time import Petdt, TimeResolution
 from pyearthtools.utils.decorators import classproperty
 
 DIRECTORY_PATTERN = "{ROOT_DIR}/{FILE_DATE}/{FILE}"
 FILE_PATTERN = "{prefix}{time}{extension}"
 
 import pyearthtools.data.logger
+
 try:
     DEFAULT_EXTENSION = pyearthtools.utils.config.get("data.patterns.default_extension")
 except:
-    DEFAULT_EXTENSION = ".nc" 
+    DEFAULT_EXTENSION = ".nc"
 
 
 def parse_time_str(time, directory: bool = False, delimiter: str | tuple | list = "") -> str:

--- a/packages/data/src/pyearthtools/data/patterns/expanded_date.py
+++ b/packages/data/src/pyearthtools/data/patterns/expanded_date.py
@@ -26,7 +26,7 @@ from pathlib import Path
 from typing import Any
 
 import pyearthtools.utils
-from pyearthtools.data import Petdt, TimeResolution
+from pyearthtools.data.time import Petdt, TimeResolution
 from pyearthtools.data.indexes import decorators
 from pyearthtools.data.patterns.default import (
     PatternForecastIndex,
@@ -38,7 +38,12 @@ from pyearthtools.utils.decorators import classproperty
 
 DIRECTORY_PATTERN = "{ROOT_DIR}/{FILE_DATE}/{FILE}"
 FILE_PATTERN = "{prefix}{time}{extension}"
-DEFAULT_EXTENSION = pyearthtools.utils.config.get("data.patterns.default_extension")
+
+import pyearthtools.data.logger
+try:
+    DEFAULT_EXTENSION = pyearthtools.utils.config.get("data.patterns.default_extension")
+except:
+    DEFAULT_EXTENSION = ".nc" 
 
 
 def parse_time_str(time, directory: bool = False, delimiter: str | tuple | list = "") -> str:

--- a/packages/data/src/pyearthtools/data/patterns/expanded_date.py
+++ b/packages/data/src/pyearthtools/data/patterns/expanded_date.py
@@ -25,18 +25,16 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+import pyearthtools.utils
 from pyearthtools.data import Petdt, TimeResolution
+from pyearthtools.data.indexes import decorators
 from pyearthtools.data.patterns.default import (
+    PatternForecastIndex,
     PatternIndex,
     PatternTimeIndex,
-    PatternForecastIndex,
     PatternVariableAware,
 )
-from pyearthtools.data.indexes import decorators
-
-import pyearthtools.utils
 from pyearthtools.utils.decorators import classproperty
-
 
 DIRECTORY_PATTERN = "{ROOT_DIR}/{FILE_DATE}/{FILE}"
 FILE_PATTERN = "{prefix}{time}{extension}"

--- a/packages/data/src/pyearthtools/data/patterns/parser.py
+++ b/packages/data/src/pyearthtools/data/patterns/parser.py
@@ -20,21 +20,18 @@ PatternIndex that parses and formats from a given str, and retrieves info from t
 
 from __future__ import annotations
 
-from collections import OrderedDict
 import itertools
-from typing import Any, Callable
+from collections import OrderedDict
 from collections.abc import Iterable
-
 from pathlib import Path
+from string import Formatter
+from typing import Any, Callable
 
 import pandas as pd
 import xarray as xr
-
-from string import Formatter
-
+from pyearthtools.data.exceptions import DataNotFoundError
 from pyearthtools.data.patterns import PatternIndex
 from pyearthtools.data.transforms import Transform, TransformCollection
-from pyearthtools.data.exceptions import DataNotFoundError
 
 
 def update_value(old_val: Any | list[Any] | tuple[Any, ...], new_vals: Any) -> list[Any]:

--- a/packages/data/src/pyearthtools/data/patterns/static.py
+++ b/packages/data/src/pyearthtools/data/patterns/static.py
@@ -19,7 +19,6 @@ from pathlib import Path
 from typing import Any
 
 import pyearthtools.data
-
 from pyearthtools.data.patterns import PatternIndex
 from pyearthtools.data.transforms import Transform, TransformCollection
 

--- a/packages/data/src/pyearthtools/data/patterns/utils.py
+++ b/packages/data/src/pyearthtools/data/patterns/utils.py
@@ -15,10 +15,9 @@
 
 from __future__ import annotations
 
-import tempfile
-import re
 import os
-
+import re
+import tempfile
 from pathlib import Path
 
 

--- a/packages/data/src/pyearthtools/data/patterns/zarr.py
+++ b/packages/data/src/pyearthtools/data/patterns/zarr.py
@@ -16,7 +16,7 @@
 import os
 
 from pyearthtools.data import patterns
-from pyearthtools.data.archive import zarr
+from pyearthtools.data.archive.zarr import ZarrIndex
 from pyearthtools.data.patterns.default import PatternIndex
 
 

--- a/packages/data/src/pyearthtools/data/patterns/zarr.py
+++ b/packages/data/src/pyearthtools/data/patterns/zarr.py
@@ -15,9 +15,8 @@
 
 import os
 
-from pyearthtools.data.archive import zarr
-
 from pyearthtools.data import patterns
+from pyearthtools.data.archive import zarr
 from pyearthtools.data.patterns.default import PatternIndex
 
 

--- a/packages/data/src/pyearthtools/data/save/array.py
+++ b/packages/data/src/pyearthtools/data/save/array.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
-from pyearthtools.data.indexes import FileSystemIndex
+from pyearthtools.data.indexes.indexes import FileSystemIndex
 from pyearthtools.data.save.save_utils import ManageFiles
 
 VALID_EXTENSIONS = [".npy", ".numpy"]

--- a/packages/data/src/pyearthtools/data/save/array.py
+++ b/packages/data/src/pyearthtools/data/save/array.py
@@ -19,7 +19,6 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
-
 from pyearthtools.data.indexes import FileSystemIndex
 from pyearthtools.data.save.save_utils import ManageFiles
 

--- a/packages/data/src/pyearthtools/data/save/dask.py
+++ b/packages/data/src/pyearthtools/data/save/dask.py
@@ -20,9 +20,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from pyearthtools.data.save.array import save as numpy_save
-
 import dask.array as da
+from pyearthtools.data.save.array import save as numpy_save
 
 
 def save(

--- a/packages/data/src/pyearthtools/data/save/dataset.py
+++ b/packages/data/src/pyearthtools/data/save/dataset.py
@@ -15,13 +15,12 @@
 
 from __future__ import annotations
 
+import warnings
 from pathlib import Path
 from typing import Any
-import warnings
-
-import xarray as xr
 
 import pyearthtools.utils
+import xarray as xr
 from pyearthtools.data.indexes import FileSystemIndex
 from pyearthtools.data.save.save_utils import ManageFiles
 

--- a/packages/data/src/pyearthtools/data/save/dataset.py
+++ b/packages/data/src/pyearthtools/data/save/dataset.py
@@ -21,7 +21,7 @@ from typing import Any
 
 import pyearthtools.utils
 import xarray as xr
-from pyearthtools.data.indexes import FileSystemIndex
+from pyearthtools.data.indexes.indexes import FileSystemIndex
 from pyearthtools.data.save.save_utils import ManageFiles
 
 VALID_EXTENSIONS = [".nc", ".netcdf"]

--- a/packages/data/src/pyearthtools/data/save/dispatcher.py
+++ b/packages/data/src/pyearthtools/data/save/dispatcher.py
@@ -14,23 +14,21 @@
 
 
 from __future__ import annotations
+
 from typing import Any
 
-import xarray as xr
-from xarray import plot as xplt
-
 import numpy as np
-
+import xarray as xr
 from matplotlib.figure import Figure
-
 from pyearthtools.data.indexes import FileSystemIndex
-from pyearthtools.data.save import dataset, json, array, plot
+from pyearthtools.data.save import array, dataset, json, plot
+from xarray import plot as xplt
 
 DASK_IMPORTED = True
 try:
     import dask
-    from dask.delayed import Delayed
     import dask.array as da
+    from dask.delayed import Delayed
     from pyearthtools.data.save import dask as dask_save
 except (ImportError, ModuleNotFoundError) as e:
     DASK_IMPORTED = False

--- a/packages/data/src/pyearthtools/data/save/dispatcher.py
+++ b/packages/data/src/pyearthtools/data/save/dispatcher.py
@@ -20,7 +20,7 @@ from typing import Any
 import numpy as np
 import xarray as xr
 from matplotlib.figure import Figure
-from pyearthtools.data.indexes import FileSystemIndex
+from pyearthtools.data.indexes.indexes import FileSystemIndex
 from pyearthtools.data.save import array, dataset, json, plot
 from xarray import plot as xplt
 

--- a/packages/data/src/pyearthtools/data/save/json.py
+++ b/packages/data/src/pyearthtools/data/save/json.py
@@ -19,7 +19,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-from pyearthtools.data.indexes import FileSystemIndex
+from pyearthtools.data.indexes.indexes import FileSystemIndex
 
 
 def save(

--- a/packages/data/src/pyearthtools/data/save/plot.py
+++ b/packages/data/src/pyearthtools/data/save/plot.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from pyearthtools.data.indexes import FileSystemIndex
+from pyearthtools.data.indexes.indexes import FileSystemIndex
 
 
 def save(

--- a/packages/data/src/pyearthtools/data/save/save_utils.py
+++ b/packages/data/src/pyearthtools/data/save/save_utils.py
@@ -15,16 +15,14 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-import uuid
-import os
-
 import logging
+import os
+import uuid
 import warnings
+from pathlib import Path
+from typing import Union
 
 from filelock import FileLock, Timeout
-
-from typing import Union
 
 VALID_PATH_TYPES = Union[str, Path, list[str], list[Path], list[Union[str, Path]]]
 

--- a/packages/data/src/pyearthtools/data/static/_geographic/__init__.py
+++ b/packages/data/src/pyearthtools/data/static/_geographic/__init__.py
@@ -26,5 +26,5 @@ from pathlib import Path
 DOWNLOAD_DATA: bool = True
 DATA_BASEDIRECTORY: Path = Path(__file__).parent.resolve().absolute()
 
-from pyearthtools.data.static._geographic.retrieval import get  # noqa: E402 F401
 from pyearthtools.data.static._geographic import retrieval
+from pyearthtools.data.static._geographic.retrieval import get  # noqa: E402 F401

--- a/packages/data/src/pyearthtools/data/static/_geographic/retrieval.py
+++ b/packages/data/src/pyearthtools/data/static/_geographic/retrieval.py
@@ -27,7 +27,6 @@ from pathlib import Path
 from typing import Literal
 
 import yaml
-
 from pyearthtools.data.exceptions import DataNotFoundError, InvalidIndexError
 from pyearthtools.data.static._geographic import DATA_BASEDIRECTORY, DOWNLOAD_DATA
 

--- a/packages/data/src/pyearthtools/data/time.py
+++ b/packages/data/src/pyearthtools/data/time.py
@@ -26,14 +26,12 @@ Subsequently, a [TimeDelta][pyearthtools.data.time.TimeDelta], and an override f
 from __future__ import annotations
 
 import datetime
-
 import functools
-from typing import Any, Generator, Literal, overload, Union
+from typing import Any, Generator, Literal, Union, overload
 
 import numpy as np
 import pandas as pd
 import yaml
-
 from pyearthtools.utils import initialisation
 
 VALID_RESOLUTIONS = Literal["year", "month", "day", "hour", "minute", "min", "second", "nanosecond"]

--- a/packages/data/src/pyearthtools/data/transforms/__init__.py
+++ b/packages/data/src/pyearthtools/data/transforms/__init__.py
@@ -48,27 +48,26 @@ class CustomTransform(pyearthtools.data.transforms.Transform):
 
 """
 
-from pyearthtools.data.transforms.transform import (
-    Transform,
-    TransformCollection,
-    FunctionTransform,
-)
-
 from pyearthtools.data.transforms import (
     aggregation,
+    attributes,
     coordinates,
     dimensions,
-    normalisation,
-    utils,
-    variables,
-    attributes,
-    optimisation,
-    values,
     interpolation,
-    region,
     mask,
+    normalisation,
+    optimisation,
+    region,
+    utils,
+    values,
+    variables,
 )
 from pyearthtools.data.transforms.default import get_default_transforms
 
 # from pyearthtools.data.transforms.mask import MaskTransform as mask
-from pyearthtools.data.transforms.derive import derive, Derive
+from pyearthtools.data.transforms.derive import Derive, derive
+from pyearthtools.data.transforms.transform import (
+    FunctionTransform,
+    Transform,
+    TransformCollection,
+)

--- a/packages/data/src/pyearthtools/data/transforms/aggregation.py
+++ b/packages/data/src/pyearthtools/data/transforms/aggregation.py
@@ -18,7 +18,8 @@ from __future__ import annotations
 from typing import Callable, Optional, Union
 
 import xarray as xr
-from pyearthtools.data.transforms import Transform, aggregation
+from pyearthtools.data.transforms.transform import Transform
+from pyearthtools.data.transforms import aggregation    
 from pyearthtools.utils.initialisation.imports import dynamic_import
 
 known_methods = ["mean", "max", "min", "sum", "std"]

--- a/packages/data/src/pyearthtools/data/transforms/aggregation.py
+++ b/packages/data/src/pyearthtools/data/transforms/aggregation.py
@@ -18,8 +18,8 @@ from __future__ import annotations
 from typing import Callable, Optional, Union
 
 import xarray as xr
+from pyearthtools.data.transforms import aggregation
 from pyearthtools.data.transforms.transform import Transform
-from pyearthtools.data.transforms import aggregation    
 from pyearthtools.utils.initialisation.imports import dynamic_import
 
 known_methods = ["mean", "max", "min", "sum", "std"]

--- a/packages/data/src/pyearthtools/data/transforms/aggregation.py
+++ b/packages/data/src/pyearthtools/data/transforms/aggregation.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 from typing import Callable, Optional, Union
 
 import xarray as xr
-
 from pyearthtools.data.transforms import Transform, aggregation
 from pyearthtools.utils.initialisation.imports import dynamic_import
 

--- a/packages/data/src/pyearthtools/data/transforms/attributes.py
+++ b/packages/data/src/pyearthtools/data/transforms/attributes.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 from typing import Any, Literal
 
 import xarray as xr
-from pyearthtools.data.transforms import Transform
+from pyearthtools.data.transforms.transform import Transform
 from pyearthtools.utils.decorators import BackwardsCompatibility
 
 

--- a/packages/data/src/pyearthtools/data/transforms/attributes.py
+++ b/packages/data/src/pyearthtools/data/transforms/attributes.py
@@ -18,10 +18,10 @@ Attribute modification
 """
 
 from __future__ import annotations
+
 from typing import Any, Literal
 
 import xarray as xr
-
 from pyearthtools.data.transforms import Transform
 from pyearthtools.utils.decorators import BackwardsCompatibility
 

--- a/packages/data/src/pyearthtools/data/transforms/coordinates.py
+++ b/packages/data/src/pyearthtools/data/transforms/coordinates.py
@@ -15,20 +15,16 @@
 
 from __future__ import annotations
 
-import warnings
-from typing import Any, Hashable, Literal, Iterable
 import logging
+import warnings
+from typing import Any, Hashable, Iterable, Literal
 
-import xarray as xr
 import numpy as np
-
-
 import pyearthtools.data
-
+import xarray as xr
+from pyearthtools.data.exceptions import DataNotFoundError
 from pyearthtools.data.transforms.transform import Transform, TransformCollection
 from pyearthtools.data.warnings import pyearthtoolsDataWarning
-from pyearthtools.data.exceptions import DataNotFoundError
-
 from pyearthtools.utils.decorators import BackwardsCompatibility
 
 DASK_IMPORTED = False

--- a/packages/data/src/pyearthtools/data/transforms/derive.py
+++ b/packages/data/src/pyearthtools/data/transforms/derive.py
@@ -27,7 +27,7 @@ from typing import Any
 
 import numpy as np
 import xarray as xr
-from pyearthtools.data.transforms import Transform
+from pyearthtools.data.transforms.transform import Transform
 from pyearthtools.utils.decorators import BackwardsCompatibility
 
 LOG = logging.getLogger("pyearthtools.data")

--- a/packages/data/src/pyearthtools/data/transforms/derive.py
+++ b/packages/data/src/pyearthtools/data/transforms/derive.py
@@ -18,16 +18,15 @@ Equation evaluation and dataset transform.
 """
 
 from __future__ import annotations
+
+import logging
+import math
+import operator
+import re
 from typing import Any
 
-import xarray as xr
 import numpy as np
-import operator
-import math
-import re
-import logging
-
-
+import xarray as xr
 from pyearthtools.data.transforms import Transform
 from pyearthtools.utils.decorators import BackwardsCompatibility
 

--- a/packages/data/src/pyearthtools/data/transforms/dimensions.py
+++ b/packages/data/src/pyearthtools/data/transforms/dimensions.py
@@ -14,10 +14,10 @@
 
 
 from __future__ import annotations
-from typing import Any, Optional, Literal, TypeVar
+
+from typing import Any, Literal, Optional, TypeVar
 
 import xarray as xr
-
 from pyearthtools.data.transforms.transform import Transform
 from pyearthtools.utils.decorators import BackwardsCompatibility
 

--- a/packages/data/src/pyearthtools/data/transforms/interpolation.py
+++ b/packages/data/src/pyearthtools/data/transforms/interpolation.py
@@ -14,18 +14,16 @@
 
 
 from __future__ import annotations
+
 from typing import Optional
 
-import xarray as xr
-from xarray.core.types import InterpOptions
 import numpy as np
-
-
 import pyearthtools.data
+import xarray as xr
 from pyearthtools.data.transforms.transform import Transform
 from pyearthtools.data.transforms.utils import parse_dataset
-
 from pyearthtools.utils.decorators import BackwardsCompatibility
+from xarray.core.types import InterpOptions
 
 xESMF_IMPORTED = True
 try:

--- a/packages/data/src/pyearthtools/data/transforms/mask.py
+++ b/packages/data/src/pyearthtools/data/transforms/mask.py
@@ -14,18 +14,15 @@
 
 
 from __future__ import annotations
+
 import operator
-
-from typing import Any, Literal, overload
-
 from pathlib import Path
+from typing import Any, Literal, overload
 
 import numpy as np
 import xarray as xr
-
 from pyearthtools.data.transforms.transform import Transform
 from pyearthtools.data.transforms.utils import parse_dataset
-
 from pyearthtools.utils.decorators import BackwardsCompatibility
 
 OPERATIONS = ["==", "!=", ">", "<", ">=", "<="]

--- a/packages/data/src/pyearthtools/data/transforms/normalisation/default.py
+++ b/packages/data/src/pyearthtools/data/transforms/normalisation/default.py
@@ -24,7 +24,7 @@ from typing import Callable, Hashable
 
 import pyearthtools.data
 import xarray as xr
-from pyearthtools.data import Petdt
+from pyearthtools.data.time import Petdt
 from pyearthtools.data.indexes.utilities.fileload import open_files
 from pyearthtools.data.transforms.normalisation._utils import format_class_name
 from pyearthtools.data.transforms.transform import (

--- a/packages/data/src/pyearthtools/data/transforms/normalisation/default.py
+++ b/packages/data/src/pyearthtools/data/transforms/normalisation/default.py
@@ -15,26 +15,23 @@
 
 from __future__ import annotations
 
+import logging
+import tempfile
+import warnings
 from abc import abstractmethod
 from pathlib import Path
 from typing import Callable, Hashable
-import warnings
-import tempfile
-import logging
-
-import xarray as xr
 
 import pyearthtools.data
-
+import xarray as xr
 from pyearthtools.data import Petdt
+from pyearthtools.data.indexes.utilities.fileload import open_files
 from pyearthtools.data.transforms.normalisation._utils import format_class_name
 from pyearthtools.data.transforms.transform import (
     FunctionTransform,
     Transform,
     get_default_transforms,
 )
-from pyearthtools.data.indexes.utilities.fileload import open_files
-
 from pyearthtools.utils.initialisation.imports import dynamic_import
 
 LOG = logging.getLogger("pyearthtools.data")

--- a/packages/data/src/pyearthtools/data/transforms/normalisation/default.py
+++ b/packages/data/src/pyearthtools/data/transforms/normalisation/default.py
@@ -24,8 +24,8 @@ from typing import Callable, Hashable
 
 import pyearthtools.data
 import xarray as xr
-from pyearthtools.data.time import Petdt
 from pyearthtools.data.indexes.utilities.fileload import open_files
+from pyearthtools.data.time import Petdt
 from pyearthtools.data.transforms.normalisation._utils import format_class_name
 from pyearthtools.data.transforms.transform import (
     FunctionTransform,

--- a/packages/data/src/pyearthtools/data/transforms/normalisation/unnormalise.py
+++ b/packages/data/src/pyearthtools/data/transforms/normalisation/unnormalise.py
@@ -20,7 +20,6 @@ import warnings
 
 import numpy as np
 import xarray as xr
-
 from pyearthtools.data.transforms.normalisation.default import Normaliser, open_file
 from pyearthtools.data.transforms.transform import FunctionTransform, Transform
 

--- a/packages/data/src/pyearthtools/data/transforms/optimisation.py
+++ b/packages/data/src/pyearthtools/data/transforms/optimisation.py
@@ -14,12 +14,11 @@
 
 
 from __future__ import annotations
-from typing import Literal, Any
 
+from typing import Any, Literal
 
 import xarray as xr
 from pyearthtools.data.transforms.transform import Transform
-
 from pyearthtools.utils.decorators import BackwardsCompatibility
 
 

--- a/packages/data/src/pyearthtools/data/transforms/region.py
+++ b/packages/data/src/pyearthtools/data/transforms/region.py
@@ -32,9 +32,7 @@ except ImportError:
 
 from pyearthtools.data.transforms import Transform
 from pyearthtools.data.transforms.utils import parse_dataset
-
 from pyearthtools.utils.decorators import BackwardsCompatibility
-
 
 RegionLookupFILE = Path(__file__).parent / "RegionLookup.yaml"
 

--- a/packages/data/src/pyearthtools/data/transforms/region.py
+++ b/packages/data/src/pyearthtools/data/transforms/region.py
@@ -30,7 +30,7 @@ try:
 except ImportError:
     GEOPANDAS_IMPORTED = False
 
-from pyearthtools.data.transforms import Transform
+from pyearthtools.data.transforms.transform import Transform
 from pyearthtools.data.transforms.utils import parse_dataset
 from pyearthtools.utils.decorators import BackwardsCompatibility
 

--- a/packages/data/src/pyearthtools/data/transforms/transform.py
+++ b/packages/data/src/pyearthtools/data/transforms/transform.py
@@ -15,20 +15,17 @@
 
 from __future__ import annotations
 
+import warnings
 from abc import ABCMeta, abstractmethod
 from types import FunctionType
-from typing import Any, Callable, Union, TypeVar
-
-import warnings
-import yaml
-from pyearthtools.data.collection import Collection
-
-import xarray as xr
+from typing import Any, Callable, TypeVar, Union
 
 import pyearthtools.data.transforms
-from pyearthtools.data.transforms.default import get_default_transforms
-
 import pyearthtools.utils
+import xarray as xr
+import yaml
+from pyearthtools.data.collection import Collection
+from pyearthtools.data.transforms.default import get_default_transforms
 from pyearthtools.utils import initialisation
 
 XR_TYPES = TypeVar("XR_TYPES", xr.DataArray, xr.Dataset, Union[xr.DataArray, xr.Dataset])

--- a/packages/data/src/pyearthtools/data/transforms/utils.py
+++ b/packages/data/src/pyearthtools/data/transforms/utils.py
@@ -19,10 +19,10 @@ Transform Utility Functions
 
 from __future__ import annotations
 
-import xarray as xr
-from typing import Any
 from pathlib import Path
+from typing import Any
 
+import xarray as xr
 
 # DEFAULT_TRANSFORM_LOCATIONS = [
 #     "__main__.",

--- a/packages/data/src/pyearthtools/data/transforms/values.py
+++ b/packages/data/src/pyearthtools/data/transforms/values.py
@@ -18,11 +18,11 @@ Transform to apply to values of datasets
 """
 
 from __future__ import annotations
+
 from typing import Literal
 
-import xarray as xr
-
 import pyearthtools.data
+import xarray as xr
 from pyearthtools.data.transforms.transform import Transform
 from pyearthtools.utils.decorators import BackwardsCompatibility
 

--- a/packages/data/src/pyearthtools/data/transforms/variables.py
+++ b/packages/data/src/pyearthtools/data/transforms/variables.py
@@ -15,11 +15,9 @@
 
 from __future__ import annotations
 
-import xarray as xr
-
 import pyearthtools.data.transforms.attributes as attr
+import xarray as xr
 from pyearthtools.data.transforms.transform import Transform
-
 from pyearthtools.utils.decorators import BackwardsCompatibility
 
 # Backwards compatability

--- a/packages/data/src/pyearthtools/data/utils.py
+++ b/packages/data/src/pyearthtools/data/utils.py
@@ -15,13 +15,11 @@
 
 from __future__ import annotations
 
-from typing import Any
-
-import re
-import os
-
-from pathlib import Path
 import logging
+import os
+import re
+from pathlib import Path
+from typing import Any
 
 LOG = logging.getLogger("pyearthtools.data")
 

--- a/packages/data/tests/data/archive/test_extensions.py
+++ b/packages/data/tests/data/archive/test_extensions.py
@@ -1,7 +1,6 @@
-import pytest
-
-from pyearthtools.data.archive import extensions
 import pyearthtools.data
+import pytest
+from pyearthtools.data.archive import extensions
 
 
 def test_register_archive():

--- a/packages/data/tests/data/archive/test_zarr.py
+++ b/packages/data/tests/data/archive/test_zarr.py
@@ -13,10 +13,9 @@
 # limitations under the License.
 
 
-import xarray as xr
-
 import pyearthtools.data
 import pytest
+import xarray as xr
 
 
 @pytest.mark.xfail

--- a/packages/data/tests/data/indexes/test_cacheIndex.py
+++ b/packages/data/tests/data/indexes/test_cacheIndex.py
@@ -1,5 +1,4 @@
 import xarray as xr
-
 from pyearthtools.data.indexes import cacheIndex
 
 

--- a/packages/data/tests/data/indexes/test_decorators.py
+++ b/packages/data/tests/data/indexes/test_decorators.py
@@ -14,7 +14,6 @@
 
 
 import pytest
-
 from pyearthtools.data.indexes import decorators
 
 

--- a/packages/data/tests/data/indexes/test_indexes.py
+++ b/packages/data/tests/data/indexes/test_indexes.py
@@ -1,8 +1,9 @@
-from pyearthtools.data import indexes
-import pyearthtools.data.archive
-from pyearthtools.data.time import Petdt
-import pytest
 import pathlib
+
+import pyearthtools.data.archive
+import pytest
+from pyearthtools.data import indexes
+from pyearthtools.data.time import Petdt
 
 
 def test_Index(monkeypatch):

--- a/packages/data/tests/data/indexes/test_modifications.py
+++ b/packages/data/tests/data/indexes/test_modifications.py
@@ -14,7 +14,6 @@
 
 
 import pytest
-
 from pyearthtools.data.indexes import FakeIndex
 
 

--- a/packages/data/tests/data/indexes/utilities/mixins/test_index_repr.py
+++ b/packages/data/tests/data/indexes/utilities/mixins/test_index_repr.py
@@ -14,9 +14,8 @@
 
 from collections import namedtuple
 
-from pyearthtools.data.indexes.utilities.mixins import index_repr
-
 from pyearthtools.data.catalog import Catalog
+from pyearthtools.data.indexes.utilities.mixins import index_repr
 
 
 class MixableTestClass(index_repr.reprMixin):

--- a/packages/data/tests/data/operations/test_interpolation.py
+++ b/packages/data/tests/data/operations/test_interpolation.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pyearthtools.data.operations import interpolation
 import xarray as xr
+from pyearthtools.data.operations import interpolation
 
 # Provides a basic forecast data structure in three dimensions
 SIMPLE_DA1 = xr.DataArray(

--- a/packages/data/tests/data/test_catalog.py
+++ b/packages/data/tests/data/test_catalog.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pyearthtools
-from pyearthtools.data import catalog
-from collections import namedtuple
-import pytest
 import io
+from collections import namedtuple
+
+import pyearthtools
+import pytest
+from pyearthtools.data import catalog
 
 
 def test_get_name():

--- a/packages/data/tests/data/time/test_time.py
+++ b/packages/data/tests/data/time/test_time.py
@@ -14,7 +14,6 @@
 
 
 import pytest
-
 from pyearthtools.data.time import Petdt, TimeDelta, TimeRange, TimeResolution
 
 

--- a/packages/data/tests/data/transform/normalisation/test_default.py
+++ b/packages/data/tests/data/transform/normalisation/test_default.py
@@ -1,10 +1,10 @@
-import pyearthtools.data.transforms.normalisation
-from pyearthtools.data.transforms.normalisation import default
-from pyearthtools.data.time import Petdt
-import pyearthtools.data.indexes
-import xarray as xr
 import numpy as np
+import pyearthtools.data.indexes
+import pyearthtools.data.transforms.normalisation
 import pytest
+import xarray as xr
+from pyearthtools.data.time import Petdt
+from pyearthtools.data.transforms.normalisation import default
 
 sample_da = xr.DataArray(
     coords={"latitude": [1, 2, 3, 4], "longitude": [1, 2, 3], "time": ["2023-02"]}, data=np.ones((4, 3, 1))

--- a/packages/data/tests/data/transform/test_aggregation.py
+++ b/packages/data/tests/data/transform/test_aggregation.py
@@ -13,9 +13,7 @@
 # limitations under the License.
 
 import xarray as xr
-
 from pyearthtools.data.transforms import aggregation
-
 
 SIMPLE_DA1 = xr.DataArray(
     [

--- a/packages/data/tests/data/transform/test_coordinates.py
+++ b/packages/data/tests/data/transform/test_coordinates.py
@@ -1,8 +1,7 @@
-from pyearthtools.data.transforms import coordinates
-import xarray as xr
 import numpy as np
 import pytest
-
+import xarray as xr
+from pyearthtools.data.transforms import coordinates
 
 # Test data, re-used across tests
 lon180 = list(range(-180, 180))

--- a/packages/data/tests/data/transform/test_derive.py
+++ b/packages/data/tests/data/transform/test_derive.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 
-import pytest
 import math
 
+import pytest
 from pyearthtools.data.transforms.derive import EquationException, evaluate
 
 

--- a/packages/data/tests/data/transform/test_mask.py
+++ b/packages/data/tests/data/transform/test_mask.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pyearthtools.data.transforms import mask
 import numpy as np
 import xarray as xr
+from pyearthtools.data.transforms import mask
 
 SIMPLE_DA1 = xr.DataArray(
     [

--- a/packages/pipeline/src/pyearthtools/pipeline/__init__.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/__init__.py
@@ -44,41 +44,35 @@ pipeline['2000-01-01T00']
 __version__ = "0.1.0"
 
 import pyearthtools.pipeline.logger
-
-from pyearthtools.pipeline.save import save, load
-from pyearthtools.pipeline.controller import Pipeline, PipelineIndex
-
-from pyearthtools.pipeline.operation import Operation
-
 from pyearthtools.pipeline import (
     branching,
+    config,
     exceptions,
     filters,
     iterators,
-    samplers,
-    operations,
     modifications,
+    operations,
+    samplers,
 )
-
-from pyearthtools.pipeline.marker import Marker, Empty
-
-from pyearthtools.pipeline.modifications import Cache, SequenceRetrieval, TemporalRetrieval
-
-from pyearthtools.pipeline.samplers import Sampler
-
-from pyearthtools.pipeline.iterators import Iterator
-
-from pyearthtools.pipeline.parallel import get_parallel
-
+from pyearthtools.pipeline.controller import Pipeline, PipelineIndex
 from pyearthtools.pipeline.exceptions import (
     PipelineException,
     PipelineFilterException,
     PipelineRuntimeError,
     PipelineTypeError,
 )
+from pyearthtools.pipeline.iterators import Iterator
+from pyearthtools.pipeline.marker import Empty, Marker
+from pyearthtools.pipeline.modifications import (
+    Cache,
+    SequenceRetrieval,
+    TemporalRetrieval,
+)
+from pyearthtools.pipeline.operation import Operation
+from pyearthtools.pipeline.parallel import get_parallel
+from pyearthtools.pipeline.samplers import Sampler
+from pyearthtools.pipeline.save import load, save
 from pyearthtools.pipeline.warnings import PipelineWarning
-
-from pyearthtools.pipeline import config
 
 __all__ = [
     "Sampler",

--- a/packages/pipeline/src/pyearthtools/pipeline/branching/__init__.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/branching/__init__.py
@@ -13,12 +13,11 @@
 # limitations under the License.
 
 
+from pyearthtools.pipeline.branching import join, split, unify
 from pyearthtools.pipeline.branching.branching import PipelineBranchPoint
-from pyearthtools.pipeline.branching.unify import Unifier
 from pyearthtools.pipeline.branching.join import Joiner
 from pyearthtools.pipeline.branching.split import Spliter
 from pyearthtools.pipeline.branching.stop import StopUndo
-
-from pyearthtools.pipeline.branching import unify, join, split
+from pyearthtools.pipeline.branching.unify import Unifier
 
 __all__ = ["PipelineBranchPoint", "Unifier", "Joiner", "Spliter"]

--- a/packages/pipeline/src/pyearthtools/pipeline/branching/branching.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/branching/branching.py
@@ -15,22 +15,19 @@
 
 from __future__ import annotations
 
-from typing import Any, Literal, Optional, Union
 import warnings
+from typing import Any, Literal, Optional, Union
 
 import graphviz
-
 from pyearthtools.data.indexes import Index
 from pyearthtools.data.transforms import Transform, TransformCollection
-
-from pyearthtools.pipeline.step import PipelineStep
-from pyearthtools.pipeline.controller import PipelineIndex, Pipeline, _Pipeline
-from pyearthtools.pipeline.operation import Operation
-
 from pyearthtools.pipeline import parallel
-from pyearthtools.pipeline.warnings import PipelineWarning
-from pyearthtools.pipeline.validation import filter_steps
+from pyearthtools.pipeline.controller import Pipeline, PipelineIndex, _Pipeline
 from pyearthtools.pipeline.exceptions import PipelineRuntimeError
+from pyearthtools.pipeline.operation import Operation
+from pyearthtools.pipeline.step import PipelineStep
+from pyearthtools.pipeline.validation import filter_steps
+from pyearthtools.pipeline.warnings import PipelineWarning
 
 
 def get_key_from_steps(key: str, steps: tuple[Any, ...]):

--- a/packages/pipeline/src/pyearthtools/pipeline/branching/join.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/branching/join.py
@@ -14,9 +14,9 @@
 
 
 from __future__ import annotations
-from abc import abstractmethod
-from typing import Any, Literal, Type, Optional, Union
 
+from abc import abstractmethod
+from typing import Any, Literal, Optional, Type, Union
 
 from pyearthtools.pipeline.operation import Operation
 

--- a/packages/pipeline/src/pyearthtools/pipeline/branching/split.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/branching/split.py
@@ -14,9 +14,9 @@
 
 
 from __future__ import annotations
-from abc import abstractmethod
-from typing import Any, Literal, Type, TypeVar, Optional, Union
 
+from abc import abstractmethod
+from typing import Any, Literal, Optional, Type, TypeVar, Union
 
 from pyearthtools.pipeline.operation import Operation
 

--- a/packages/pipeline/src/pyearthtools/pipeline/branching/unify.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/branching/unify.py
@@ -14,13 +14,12 @@
 
 
 from __future__ import annotations
+
 from abc import ABCMeta, abstractmethod
 from typing import Any, Union
 
-
-from pyearthtools.pipeline.operation import Operation
 from pyearthtools.pipeline.exceptions import PipelineUnificationException
-
+from pyearthtools.pipeline.operation import Operation
 
 __all__ = ["Unifier", "Equality"]
 

--- a/packages/pipeline/src/pyearthtools/pipeline/controller.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/controller.py
@@ -18,30 +18,28 @@ Pipeline Controller
 
 from __future__ import annotations
 
-from abc import ABCMeta, abstractmethod
-
-from typing import Any, ContextManager, Literal, Union, Optional, Type, overload
-from pathlib import Path
+import builtins
 import functools
 import logging
+from abc import ABCMeta, abstractmethod
+from pathlib import Path
+from typing import Any, ContextManager, Literal, Optional, Type, Union, overload
 
-import builtins
 import graphviz
-
+import pyearthtools.pipeline
 import pyearthtools.utils
-
 from pyearthtools.data.indexes import Index
 from pyearthtools.data.transforms import Transform, TransformCollection
-
-import pyearthtools.pipeline
-from pyearthtools.pipeline.recording import PipelineRecordingMixin
-from pyearthtools.pipeline import samplers, iterators, filters
-from pyearthtools.pipeline.step import PipelineStep
-from pyearthtools.pipeline.operation import Operation
-from pyearthtools.pipeline.exceptions import PipelineFilterException, ExceptionIgnoreContext
-from pyearthtools.pipeline.validation import filter_steps
+from pyearthtools.pipeline import filters, iterators, samplers
+from pyearthtools.pipeline.exceptions import (
+    ExceptionIgnoreContext,
+    PipelineFilterException,
+)
 from pyearthtools.pipeline.graph import Graphed, format_graph_node
-
+from pyearthtools.pipeline.operation import Operation
+from pyearthtools.pipeline.recording import PipelineRecordingMixin
+from pyearthtools.pipeline.step import PipelineStep
+from pyearthtools.pipeline.validation import filter_steps
 
 PIPELINE_TYPES = Union[Index, PipelineStep, Transform, TransformCollection]
 VALID_PIPELINE_TYPES = Union[PIPELINE_TYPES, tuple[PIPELINE_TYPES, ...], tuple[tuple, ...]]
@@ -773,7 +771,7 @@ class Pipeline(_Pipeline, Index):
 
     def _ipython_display_(self):
         """Override for repr of `Pipeline`, shows initialisation arguments and graph"""
-        from IPython.core.display import display, HTML
+        from IPython.core.display import HTML, display
 
         display(HTML(self._repr_html_()))
 

--- a/packages/pipeline/src/pyearthtools/pipeline/exceptions.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/exceptions.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 
-from typing import Any, Optional, Type
 import warnings
+from typing import Any, Optional, Type
 
 import pyearthtools.utils
 from pyearthtools.pipeline.warnings import PipelineWarning

--- a/packages/pipeline/src/pyearthtools/pipeline/filters.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/filters.py
@@ -13,15 +13,13 @@
 # limitations under the License.
 
 
-from abc import abstractmethod, ABCMeta
+import warnings
+from abc import ABCMeta, abstractmethod
 from typing import Optional, Type, Union
 
-import warnings
-
 import pyearthtools.utils
-
-from pyearthtools.pipeline.step import PipelineStep
 from pyearthtools.pipeline.exceptions import PipelineFilterException
+from pyearthtools.pipeline.step import PipelineStep
 from pyearthtools.pipeline.warnings import PipelineWarning
 
 __all__ = ["Filter", "FilterCheck", "FilterWarningContext", "TypeFilter"]

--- a/packages/pipeline/src/pyearthtools/pipeline/graph.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/graph.py
@@ -17,9 +17,8 @@ from abc import abstractmethod
 from typing import Any, Optional
 
 import graphviz
-
-from pyearthtools.data import Index
 import pyearthtools.pipeline
+from pyearthtools.data import Index
 
 
 def format_graph_node(obj, parent: Optional[list[str]]) -> dict[str, Any]:

--- a/packages/pipeline/src/pyearthtools/pipeline/iterators.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/iterators.py
@@ -20,16 +20,14 @@ Allows a pipeline to be iterated over, and data retrieved from.
 """
 
 from __future__ import annotations
-from functools import cached_property
-from abc import ABCMeta, abstractmethod
 
-from typing import Any, Callable, Generator, Hashable, Iterable, Optional, Union
+from abc import ABCMeta, abstractmethod
+from functools import cached_property
 from pathlib import Path
+from typing import Any, Callable, Generator, Hashable, Iterable, Optional, Union
 
 import numpy as np
-
 import pyearthtools.data
-
 from pyearthtools.pipeline.recording import PipelineRecordingMixin
 
 

--- a/packages/pipeline/src/pyearthtools/pipeline/iterators.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/iterators.py
@@ -27,8 +27,8 @@ from pathlib import Path
 from typing import Any, Callable, Generator, Hashable, Iterable, Optional, Union
 
 import numpy as np
-from pyearthtools.pipeline.recording import PipelineRecordingMixin
 import pyearthtools.data.time
+from pyearthtools.pipeline.recording import PipelineRecordingMixin
 
 
 class Iterator(PipelineRecordingMixin, metaclass=ABCMeta):

--- a/packages/pipeline/src/pyearthtools/pipeline/iterators.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/iterators.py
@@ -27,8 +27,8 @@ from pathlib import Path
 from typing import Any, Callable, Generator, Hashable, Iterable, Optional, Union
 
 import numpy as np
-import pyearthtools.data
 from pyearthtools.pipeline.recording import PipelineRecordingMixin
+import pyearthtools.data.time
 
 
 class Iterator(PipelineRecordingMixin, metaclass=ABCMeta):
@@ -176,22 +176,22 @@ class DateRange(Iterator):
         Args:
             start (str):
                 Start time. Must be understandable by
-                `pyearthtools.data.Petdt`.
+                `pyearthtools.data.time.Petdt`.
             end (str):
                 End time. Must be understandable by
-                `pyearthtools.data.Petdt`.
+                `pyearthtools.data.time.Petdt`.
             interval (Any):
                 Interval between times. Must be understandable by
-                `pyearthtools.data.TimeDelta`.
+                `pyearthtools.data.time.TimeDelta`.
         """
         super().__init__()
         self.record_initialisation()
 
         import pyearthtools.data
 
-        self._timerange = pyearthtools.data.TimeRange(start, end, interval)
+        self._timerange = pyearthtools.data.time.TimeRange(start, end, interval)
 
-    def __iter__(self) -> Generator[pyearthtools.data.Petdt, None, None]:
+    def __iter__(self) -> Generator[pyearthtools.data.time.Petdt, None, None]:
         for i in self._timerange:
             yield i
 
@@ -212,12 +212,12 @@ class DateRangeLimit(DateRange):
                 Start time
             interval (Any):
                 Interval between times. Must be understandable by
-                `pyearthtools.data.TimeDelta`.
+                `pyearthtools.data.time.TimeDelta`.
             num (int):
                 Number of total samples to iterate over.
         """
 
-        end = pyearthtools.data.Petdt(start) + (pyearthtools.data.TimeDelta(interval) * num)
+        end = pyearthtools.data.time.Petdt(start) + (pyearthtools.data.time.TimeDelta(interval) * num)
         super().__init__(start, str(end), interval)
 
 

--- a/packages/pipeline/src/pyearthtools/pipeline/marker.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/marker.py
@@ -14,7 +14,6 @@
 
 
 import xarray as xr
-
 from pyearthtools.pipeline.graph import Graphed
 from pyearthtools.pipeline.operation import PipelineStep
 

--- a/packages/pipeline/src/pyearthtools/pipeline/modifications/__init__.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/modifications/__init__.py
@@ -13,17 +13,15 @@
 # limitations under the License.
 
 
+from pyearthtools.pipeline.modifications import idx_modification
+from pyearthtools.pipeline.modifications.cache import Cache, MemCache, StaticCache
 from pyearthtools.pipeline.modifications.idx_modification import (
     IdxModifier,
     IdxOverride,
-    TimeIdxModifier,
     SequenceRetrieval,
     TemporalRetrieval,
+    TimeIdxModifier,
 )
-from pyearthtools.pipeline.modifications.cache import Cache, StaticCache, MemCache
-
-
-from pyearthtools.pipeline.modifications import idx_modification
 
 __all__ = [
     "Cache",

--- a/packages/pipeline/src/pyearthtools/pipeline/modifications/cache.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/modifications/cache.py
@@ -15,19 +15,17 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional, Union, Literal
-import warnings
-
-from pathlib import Path
-from hashlib import sha512
 import shutil
+import warnings
+from hashlib import sha512
+from pathlib import Path
+from typing import Any, Literal, Optional, Union
 
 import pyearthtools.data
 from pyearthtools.data.patterns import PatternIndex
-
 from pyearthtools.pipeline.controller import PipelineIndex
-from pyearthtools.pipeline.warnings import PipelineWarning
 from pyearthtools.pipeline.exceptions import PipelineRuntimeError
+from pyearthtools.pipeline.warnings import PipelineWarning
 
 CACHE_HASH_NAME = ".cache_hash"
 PIPELINE_SAVE_NAME = "pipeline.yaml"

--- a/packages/pipeline/src/pyearthtools/pipeline/modifications/idx_modification.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/modifications/idx_modification.py
@@ -216,7 +216,7 @@ class IdxModifier(PipelineIndex, ParallelEnabledMixin):
 
 
 class TimeIdxModifier(IdxModifier):
-    """`IdxModifier` which converts all `modification`'s to `pyearthtools.data.TimeDelta`"""
+    """`IdxModifier` which converts all `modification`'s to `pyearthtools.data.time.TimeDelta`"""
 
     def __init__(
         self,
@@ -225,7 +225,7 @@ class TimeIdxModifier(IdxModifier):
         **kwargs,
     ):
         """
-        Modify `idx` but convert all `modification`'s to `pyearthtools.data.TimeDelta`
+        Modify `idx` but convert all `modification`'s to `pyearthtools.data.time.TimeDelta`
 
         Args:
             modification (Union[Any, tuple[Union[Any, tuple[Any, ...]], ...]]):
@@ -249,7 +249,7 @@ class TimeIdxModifier(IdxModifier):
             """Map elements to `TimeDelta`"""
             if can_map(mod):
                 return tuple(map(map_to_time, mod))
-            return pyearthtools.data.TimeDelta(mod)
+            return pyearthtools.data.time.TimeDelta(mod)
 
         if extra_mods:
             modification = (
@@ -426,7 +426,7 @@ class SequenceRetrieval(IdxModifier):
 class TemporalRetrieval(SequenceRetrieval):
     """
     Retrieve a sequence of samples from `SequenceRetrieval`,
-    but force all indexes to be an `pyearthtools.data.Petdt`.
+    but force all indexes to be an `pyearthtools.data.time.Petdt`.
 
     Examples:
         >>> TemporalRetrieval(-6)['2000-01-01T12']
@@ -447,15 +447,15 @@ class TemporalRetrieval(SequenceRetrieval):
         def map_to_tuple(mod):
             if isinstance(mod, tuple):
                 return tuple(map(map_to_tuple, mod))
-            return pyearthtools.data.TimeDelta((mod, delta_unit))
+            return pyearthtools.data.time.TimeDelta((mod, delta_unit))
 
         if delta_unit is not None:
             self._modification = map_to_tuple(self._modification)
 
     def __getitem__(self, idx: Any):
-        if not isinstance(idx, pyearthtools.data.Petdt):
-            if not pyearthtools.data.Petdt.is_time(idx):
-                raise TypeError(f"Cannot convert {idx!r} to `pyearthtools.data.Petdt`.")
-            idx = pyearthtools.data.Petdt(idx)
+        if not isinstance(idx, pyearthtools.data.time.Petdt):
+            if not pyearthtools.data.time.Petdt.is_time(idx):
+                raise TypeError(f"Cannot convert {idx!r} to `pyearthtools.data.time.Petdt`.")
+            idx = pyearthtools.data.time.Petdt(idx)
 
         return super().__getitem__(idx)

--- a/packages/pipeline/src/pyearthtools/pipeline/modifications/idx_modification.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/modifications/idx_modification.py
@@ -17,24 +17,21 @@
 
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass
 from typing import Any, Callable, Iterable, Optional, Type, Union
-import warnings
 
-import xarray as xr
 import numpy as np
-
 import pyearthtools.data
-
-
+import xarray as xr
 from pyearthtools.pipeline.controller import PipelineIndex
 from pyearthtools.pipeline.parallel import ParallelEnabledMixin
 from pyearthtools.pipeline.warnings import PipelineWarning
 
 DASK_IMPORTED = True
 try:
-    from dask.delayed import Delayed, delayed
     import dask.array as da
+    from dask.delayed import Delayed, delayed
 except (ImportError, ModuleNotFoundError) as _:
     DASK_IMPORTED = False
 

--- a/packages/pipeline/src/pyearthtools/pipeline/operation.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operation.py
@@ -18,11 +18,9 @@ from __future__ import annotations
 from typing import Literal, Optional, Type, Union
 
 import numpy as np
-
-from pyearthtools.pipeline.step import PipelineStep
-
-from pyearthtools.pipeline.decorators import potentialabstractmethod, PotentialABC
 from pyearthtools.pipeline import parallel
+from pyearthtools.pipeline.decorators import PotentialABC, potentialabstractmethod
+from pyearthtools.pipeline.step import PipelineStep
 
 __all__ = ["Operation"]
 

--- a/packages/pipeline/src/pyearthtools/pipeline/operations/__init__.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/__init__.py
@@ -26,9 +26,8 @@ Pipeline Operations
 
 import warnings
 
-from pyearthtools.pipeline.operations import xarray, numpy
+from pyearthtools.pipeline.operations import numpy, transform, xarray
 from pyearthtools.pipeline.operations.transforms import Transforms
-from pyearthtools.pipeline.operations import transform
 
 try:
     from pyearthtools.pipeline.operations import dask

--- a/packages/pipeline/src/pyearthtools/pipeline/operations/dask/__init__.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/dask/__init__.py
@@ -31,19 +31,22 @@ Dask operations
 """
 
 
-from pyearthtools.pipeline.operations.dask.join import Stack, Concatenate, VStack, HStack
-
-from pyearthtools.pipeline.operations.dask.compute import Compute
-
 from pyearthtools.pipeline.operations.dask import (
     augment,
+    conversion,
     filters,
     normalisation,
     reshape,
     select,
     split,
     values,
-    conversion,
+)
+from pyearthtools.pipeline.operations.dask.compute import Compute
+from pyearthtools.pipeline.operations.dask.join import (
+    Concatenate,
+    HStack,
+    Stack,
+    VStack,
 )
 
 __all__ = [

--- a/packages/pipeline/src/pyearthtools/pipeline/operations/dask/augment.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/dask/augment.py
@@ -20,7 +20,6 @@
 
 import dask.array as da
 import numpy as np
-
 from pyearthtools.pipeline.operations.dask.dask import DaskOperation
 
 

--- a/packages/pipeline/src/pyearthtools/pipeline/operations/dask/compute.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/dask/compute.py
@@ -18,9 +18,7 @@
 from typing import TypeVar
 
 import dask.array as da
-
 from dask.delayed import Delayed
-
 from pyearthtools.pipeline.operations.dask.dask import DaskOperation
 
 T = TypeVar("T", da.Array, Delayed)

--- a/packages/pipeline/src/pyearthtools/pipeline/operations/dask/conversion.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/dask/conversion.py
@@ -16,13 +16,11 @@
 # type: ignore[reportPrivateImportUsage]
 
 
-from typing import Any, Optional, Union, Hashable
+from typing import Any, Hashable, Optional, Union
 
 import dask.array as da
-import xarray as xr
-
 import pyearthtools.data
-
+import xarray as xr
 from pyearthtools.pipeline.operations.dask.dask import DaskOperation
 
 ATTRIBUTES_IGNORE = ["license", "summary"]

--- a/packages/pipeline/src/pyearthtools/pipeline/operations/dask/dask.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/dask/dask.py
@@ -19,13 +19,11 @@
 Dask specific operation
 """
 
-from typing import Type, Union, Optional
-
 import functools
+from typing import Optional, Type, Union
+
 import numpy as np
-
 import pyearthtools.utils
-
 from pyearthtools.pipeline.operation import Operation
 
 

--- a/packages/pipeline/src/pyearthtools/pipeline/operations/dask/filters.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/dask/filters.py
@@ -20,7 +20,6 @@ from typing import Literal, Union
 
 import dask.array as da
 import numpy as np
-
 from pyearthtools.pipeline.filters import Filter, PipelineFilterException
 
 

--- a/packages/pipeline/src/pyearthtools/pipeline/operations/dask/join.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/dask/join.py
@@ -15,10 +15,9 @@
 
 # type: ignore[reportPrivateImportUsage]
 
-from typing import Optional, Any
+from typing import Any, Optional
 
 import dask.array as da
-
 from pyearthtools.pipeline.branching.join import Joiner
 from pyearthtools.pipeline.operations.dask.dask import DaskOperation
 

--- a/packages/pipeline/src/pyearthtools/pipeline/operations/dask/normalisation.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/dask/normalisation.py
@@ -19,16 +19,11 @@ from abc import abstractmethod
 from pathlib import Path
 from typing import Union
 
-
-import numpy as np
 import dask.array as da
-
-
+import numpy as np
 from pyearthtools.data.utils import parse_path
-
-from pyearthtools.utils.decorators import BackwardsCompatibility
 from pyearthtools.pipeline.operations.dask.dask import DaskOperation
-
+from pyearthtools.utils.decorators import BackwardsCompatibility
 
 FILE = Union[str, Path]
 

--- a/packages/pipeline/src/pyearthtools/pipeline/operations/dask/reshape.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/dask/reshape.py
@@ -15,15 +15,13 @@
 
 # type: ignore[reportPrivateImportUsage]
 
-from typing import Union, Optional, Any
-
 import math
-import einops
+from typing import Any, Optional, Union
 
-import numpy as np
 import dask.array as da
+import einops
+import numpy as np
 from dask.delayed import delayed
-
 from pyearthtools.pipeline.operations.dask.dask import DaskOperation
 
 

--- a/packages/pipeline/src/pyearthtools/pipeline/operations/dask/select.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/dask/select.py
@@ -18,7 +18,6 @@
 from typing import Optional
 
 import dask.array as da
-
 from pyearthtools.pipeline.operations.dask.dask import DaskOperation
 
 

--- a/packages/pipeline/src/pyearthtools/pipeline/operations/dask/split.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/dask/split.py
@@ -18,7 +18,6 @@
 from typing import Optional
 
 import dask.array as da
-
 from pyearthtools.pipeline.branching.split import Spliter
 from pyearthtools.pipeline.operations.dask.dask import DaskOperation
 

--- a/packages/pipeline/src/pyearthtools/pipeline/operations/dask/values.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/dask/values.py
@@ -15,13 +15,11 @@
 
 # type: ignore[reportPrivateImportUsage]
 
-from typing import Literal, Union, Optional
+from typing import Literal, Optional, Union
 
 import dask.array as da
 import numpy as np
-
 import pyearthtools.data
-
 from pyearthtools.pipeline.operations.dask.dask import DaskOperation
 
 

--- a/packages/pipeline/src/pyearthtools/pipeline/operations/numpy/__init__.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/numpy/__init__.py
@@ -27,17 +27,21 @@ Numpy Operations
 | split  | Split numpy arrays into tuples | `OnAxis`, `OnSlice`, `VSplit`, `HSplit` |
 | values | Modify values of arrays | `FillNan`, `MaskValue`, `ForceNormalised` |
 """
-from pyearthtools.pipeline.operations.numpy.join import Stack, Concatenate, VStack, HStack
-
 from pyearthtools.pipeline.operations.numpy import (
     augment,
+    conversion,
     filters,
     normalisation,
     reshape,
     select,
     split,
     values,
-    conversion,
+)
+from pyearthtools.pipeline.operations.numpy.join import (
+    Concatenate,
+    HStack,
+    Stack,
+    VStack,
 )
 
 __all__ = [

--- a/packages/pipeline/src/pyearthtools/pipeline/operations/numpy/augment.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/numpy/augment.py
@@ -14,7 +14,6 @@
 
 
 import numpy as np
-
 from pyearthtools.pipeline.operation import Operation
 
 

--- a/packages/pipeline/src/pyearthtools/pipeline/operations/numpy/conversion.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/numpy/conversion.py
@@ -13,13 +13,11 @@
 # limitations under the License.
 
 
-from typing import Any, Optional, Union, Hashable
+from typing import Any, Hashable, Optional, Union
 
 import numpy as np
-import xarray as xr
-
 import pyearthtools.data
-
+import xarray as xr
 from pyearthtools.pipeline.operation import Operation
 
 ATTRIBUTES_IGNORE = ["license", "summary"]

--- a/packages/pipeline/src/pyearthtools/pipeline/operations/numpy/join.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/numpy/join.py
@@ -13,10 +13,9 @@
 # limitations under the License.
 
 
-from typing import Optional, Any
+from typing import Any, Optional
 
 import numpy as np
-
 from pyearthtools.pipeline.branching.join import Joiner
 
 

--- a/packages/pipeline/src/pyearthtools/pipeline/operations/numpy/normalisation.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/numpy/normalisation.py
@@ -18,12 +18,9 @@ from pathlib import Path
 from typing import Union
 
 import numpy as np
-
 from pyearthtools.data.utils import parse_path
-
-from pyearthtools.utils.decorators import BackwardsCompatibility
 from pyearthtools.pipeline.operation import Operation
-
+from pyearthtools.utils.decorators import BackwardsCompatibility
 
 FILE = Union[str, Path]
 

--- a/packages/pipeline/src/pyearthtools/pipeline/operations/numpy/reshape.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/numpy/reshape.py
@@ -13,12 +13,11 @@
 # limitations under the License.
 
 
-from typing import Union, Optional, Any
-
 import math
+from typing import Any, Optional, Union
+
 import einops
 import numpy as np
-
 from pyearthtools.pipeline.operation import Operation
 
 

--- a/packages/pipeline/src/pyearthtools/pipeline/operations/numpy/select.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/numpy/select.py
@@ -16,7 +16,6 @@
 from typing import Any, Optional
 
 import numpy as np
-
 from pyearthtools.pipeline.operation import Operation
 
 

--- a/packages/pipeline/src/pyearthtools/pipeline/operations/numpy/split.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/numpy/split.py
@@ -16,8 +16,6 @@
 from typing import Optional
 
 import numpy as np
-
-
 from pyearthtools.pipeline.branching.split import Spliter
 
 

--- a/packages/pipeline/src/pyearthtools/pipeline/operations/numpy/values.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/numpy/values.py
@@ -13,12 +13,10 @@
 # limitations under the License.
 
 
-from typing import Literal, Union, Optional
+from typing import Literal, Optional, Union
 
 import numpy as np
-
 import pyearthtools.data
-
 from pyearthtools.pipeline.operation import Operation
 
 

--- a/packages/pipeline/src/pyearthtools/pipeline/operations/transform/__init__.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/transform/__init__.py
@@ -15,5 +15,5 @@
 
 """Pipeline specific transforms"""
 
-from pyearthtools.pipeline.operations.transform.add_variables import TimeOfYear
 from pyearthtools.pipeline.operations.transform.add_coordinates import AddCoordinates
+from pyearthtools.pipeline.operations.transform.add_variables import TimeOfYear

--- a/packages/pipeline/src/pyearthtools/pipeline/operations/transform/add_coordinates.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/transform/add_coordinates.py
@@ -17,9 +17,8 @@ import logging
 from typing import Any, Union
 
 import numpy as np
-import xarray as xr
-
 import pyearthtools.data
+import xarray as xr
 from pyearthtools.data import Transform
 
 LOG = logging.getLogger("pyearthtools.pipeline")

--- a/packages/pipeline/src/pyearthtools/pipeline/operations/transforms.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/transforms.py
@@ -13,11 +13,10 @@
 # limitations under the License.
 
 
-from typing import Any, TypeVar, Union, Optional
-
-import xarray as xr
+from typing import Any, Optional, TypeVar, Union
 
 import pyearthtools.data
+import xarray as xr
 from pyearthtools.pipeline.operation import Operation
 
 T = TypeVar("T", xr.Dataset, xr.DataArray)

--- a/packages/pipeline/src/pyearthtools/pipeline/operations/xarray/__init__.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/xarray/__init__.py
@@ -33,22 +33,21 @@ xarray Operations
 | remapping | Reproject data | `HEALPix` |
 """
 
-from pyearthtools.pipeline.operations.xarray.compute import Compute
-from pyearthtools.pipeline.operations.xarray.join import Merge, Concatenate
-from pyearthtools.pipeline.operations.xarray.sort import Sort
-from pyearthtools.pipeline.operations.xarray.chunk import Chunk
-
 from pyearthtools.pipeline.operations.xarray import (
     conversion,
     filters,
+    metadata,
+    normalisation,
+    remapping,
     reshape,
     select,
     split,
     values,
-    metadata,
-    normalisation,
-    remapping,
 )
+from pyearthtools.pipeline.operations.xarray.chunk import Chunk
+from pyearthtools.pipeline.operations.xarray.compute import Compute
+from pyearthtools.pipeline.operations.xarray.join import Concatenate, Merge
+from pyearthtools.pipeline.operations.xarray.sort import Sort
 
 __all__ = [
     "Compute",

--- a/packages/pipeline/src/pyearthtools/pipeline/operations/xarray/chunk.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/xarray/chunk.py
@@ -13,10 +13,9 @@
 # limitations under the License.
 
 
-from typing import TypeVar, Optional, Literal
+from typing import Literal, Optional, TypeVar
 
 import xarray as xr
-
 from pyearthtools.pipeline.operation import Operation
 
 T = TypeVar("T", xr.Dataset, xr.DataArray)

--- a/packages/pipeline/src/pyearthtools/pipeline/operations/xarray/compute.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/xarray/compute.py
@@ -16,7 +16,6 @@
 from typing import TypeVar
 
 import xarray as xr
-
 from pyearthtools.pipeline.operation import Operation
 
 T = TypeVar("T", xr.Dataset, xr.DataArray)

--- a/packages/pipeline/src/pyearthtools/pipeline/operations/xarray/conversion.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/xarray/conversion.py
@@ -16,15 +16,13 @@
 # type: ignore[reportPrivateImportUsage]
 
 
-from typing import Optional, Union, TypeVar
 from pathlib import Path
+from typing import Optional, TypeVar, Union
 
 import numpy as np
 import xarray as xr
-
-from pyearthtools.utils.data import converter
-
 from pyearthtools.pipeline.operation import Operation
+from pyearthtools.utils.data import converter
 
 XARRAY_OBJECTS = TypeVar("XARRAY_OBJECTS", xr.Dataset, xr.DataArray)
 FILE_TYPES = Union[str, Path]

--- a/packages/pipeline/src/pyearthtools/pipeline/operations/xarray/filters.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/xarray/filters.py
@@ -13,13 +13,11 @@
 # limitations under the License.
 
 
+import math
 from typing import Literal, Optional, TypeVar, Union
 
 import numpy as np
 import xarray as xr
-
-import math
-
 from pyearthtools.pipeline.filters import Filter, PipelineFilterException
 
 T = TypeVar("T", xr.Dataset, xr.DataArray)

--- a/packages/pipeline/src/pyearthtools/pipeline/operations/xarray/join.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/xarray/join.py
@@ -14,10 +14,9 @@
 
 
 from functools import reduce
-from typing import TypeVar, Union, Optional, Any
+from typing import Any, Optional, TypeVar, Union
 
 import xarray as xr
-
 from pyearthtools.pipeline.branching.join import Joiner
 
 T = TypeVar("T", xr.Dataset, xr.DataArray)

--- a/packages/pipeline/src/pyearthtools/pipeline/operations/xarray/metadata.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/xarray/metadata.py
@@ -13,12 +13,10 @@
 # limitations under the License.
 
 
-from typing import TypeVar, Optional, Any, Literal
-
-import xarray as xr
+from typing import Any, Literal, Optional, TypeVar
 
 import pyearthtools.data
-
+import xarray as xr
 from pyearthtools.pipeline.operation import Operation
 
 T = TypeVar("T", xr.Dataset, xr.DataArray)

--- a/packages/pipeline/src/pyearthtools/pipeline/operations/xarray/normalisation.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/xarray/normalisation.py
@@ -18,12 +18,9 @@ from pathlib import Path
 from typing import TypeVar, Union
 
 import xarray as xr
-
 from pyearthtools.data.utils import parse_path
-
-from pyearthtools.utils.decorators import BackwardsCompatibility
 from pyearthtools.pipeline.operation import Operation
-
+from pyearthtools.utils.decorators import BackwardsCompatibility
 
 FILE = Union[str, Path]
 

--- a/packages/pipeline/src/pyearthtools/pipeline/operations/xarray/remapping/base.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/xarray/remapping/base.py
@@ -17,10 +17,10 @@
 Remapping Operations.
 """
 
-from abc import abstractmethod, ABCMeta
+from abc import ABCMeta, abstractmethod
 from typing import Type, TypeVar
-import xarray as xr
 
+import xarray as xr
 from pyearthtools.pipeline import Operation
 
 XR_TYPE = TypeVar("XR_TYPE", xr.Dataset, xr.DataArray)

--- a/packages/pipeline/src/pyearthtools/pipeline/operations/xarray/remapping/healpix.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/xarray/remapping/healpix.py
@@ -43,24 +43,20 @@ Details on the HEALPix can be found at https://iopscience.iop.org/article/10.108
 """
 
 
-from typing import TypeVar, Literal, Optional
-
 import functools
-import warnings
-
-import numpy as np
-import healpy as hp
-import xarray as xr
-import reproject as rp
-import astropy as ap
-
 import logging
+import warnings
+from typing import Literal, Optional, TypeVar
 
+import astropy as ap
+import healpy as hp
+import numpy as np
 import pyearthtools.data
+import reproject as rp
+import xarray as xr
 from pyearthtools.pipeline.warnings import PipelineWarning
 
 from .base import BaseRemap
-
 
 XR_TYPE = TypeVar("XR_TYPE", xr.Dataset, xr.DataArray)
 

--- a/packages/pipeline/src/pyearthtools/pipeline/operations/xarray/reshape.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/xarray/reshape.py
@@ -15,9 +15,8 @@
 
 from typing import Hashable, TypeVar, Union
 
-import xarray as xr
-
 import pyearthtools.data
+import xarray as xr
 from pyearthtools.pipeline.operation import Operation
 
 T = TypeVar("T", xr.Dataset, xr.DataArray)

--- a/packages/pipeline/src/pyearthtools/pipeline/operations/xarray/select.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/xarray/select.py
@@ -13,12 +13,10 @@
 # limitations under the License.
 
 
-from typing import Any, Literal, Union, Optional
-
-import xarray as xr
-
+from typing import Any, Literal, Optional, Union
 
 import pyearthtools.data
+import xarray as xr
 from pyearthtools.pipeline.operation import Operation
 
 

--- a/packages/pipeline/src/pyearthtools/pipeline/operations/xarray/sort.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/xarray/sort.py
@@ -13,10 +13,9 @@
 # limitations under the License.
 
 
-from typing import TypeVar, Optional
+from typing import Optional, TypeVar
 
 import xarray as xr
-
 from pyearthtools.pipeline.operation import Operation
 
 T = TypeVar("T", xr.Dataset, xr.DataArray)

--- a/packages/pipeline/src/pyearthtools/pipeline/operations/xarray/split.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/xarray/split.py
@@ -13,10 +13,9 @@
 # limitations under the License.
 
 
-from typing import TypeVar, Union, Optional, Any
+from typing import Any, Optional, TypeVar, Union
 
 import xarray as xr
-
 from pyearthtools.pipeline.branching.split import Spliter
 
 T = TypeVar("T", xr.Dataset, xr.DataArray)

--- a/packages/pipeline/src/pyearthtools/pipeline/operations/xarray/values.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/xarray/values.py
@@ -13,13 +13,11 @@
 # limitations under the License.
 
 
-from typing import TypeVar, Union, Optional, Any, Literal
+from typing import Any, Literal, Optional, TypeVar, Union
 
-import xarray as xr
 import numpy as np
-
 import pyearthtools.data
-
+import xarray as xr
 from pyearthtools.pipeline.operation import Operation
 
 T = TypeVar("T", xr.Dataset, xr.DataArray)

--- a/packages/pipeline/src/pyearthtools/pipeline/parallel.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/parallel.py
@@ -23,17 +23,14 @@ Therefore, if dask is available and enabled, it can be automatically used, but i
 no code is needed to be changed to run in serial.
 """
 
-from abc import abstractmethod
 import functools
-
-from importlib.util import find_spec
-
 import logging
-from typing import Callable, Literal, Optional, Type, TypeVar, Any, Union
-
-from pyearthtools.utils.decorators import classproperty
+from abc import abstractmethod
+from importlib.util import find_spec
+from typing import Any, Callable, Literal, Optional, Type, TypeVar, Union
 
 import pyearthtools.utils
+from pyearthtools.utils.decorators import classproperty
 
 Future = TypeVar("Future", Any, Any)
 
@@ -159,9 +156,9 @@ class DaskParallelInterface(ParallelInterface):
     @classproperty
     def client(cls) -> "distributed.Client":  # type: ignore  # noqa: F821
         """Get dask client"""
-        from dask.distributed import Client
-        import distributed
         import dask
+        import distributed
+        from dask.distributed import Client
 
         try:
             client = distributed.get_client()
@@ -252,7 +249,7 @@ class DaskDelayedInterface(ParallelInterface):
         return self._interface_kwargs.get("Delayed", {})
 
     def run_delayed(self, func, *args, **kwargs):
-        from dask.delayed import tokenize, delayed
+        from dask.delayed import delayed, tokenize
 
         name = self.config.get("name", None)
         if name is not None:

--- a/packages/pipeline/src/pyearthtools/pipeline/samplers.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/samplers.py
@@ -20,8 +20,8 @@ Allows data to be on the fly iterated through, and sampled from the stream.
 """
 
 from __future__ import annotations
-from abc import ABCMeta, abstractmethod
 
+from abc import ABCMeta, abstractmethod
 from typing import Any, Generator, Union
 
 from pyearthtools.pipeline.recording import PipelineRecordingMixin

--- a/packages/pipeline/src/pyearthtools/pipeline/save.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/save.py
@@ -15,22 +15,17 @@
 
 """Saving and Loading of `Pipelines`"""
 
-import os
-from typing import Any, Union, Optional
-
-from pathlib import Path
-import warnings
-
-import yaml
-
 import logging
-
-from pyearthtools.data.utils import parse_path
-
-from pyearthtools.utils.initialisation.imports import dynamic_import
-from pyearthtools.utils import initialisation
+import os
+import warnings
+from pathlib import Path
+from typing import Any, Optional, Union
 
 import pyearthtools.pipeline
+import yaml
+from pyearthtools.data.utils import parse_path
+from pyearthtools.utils import initialisation
+from pyearthtools.utils.initialisation.imports import dynamic_import
 
 CONFIG_KEY = "--CONFIG--"
 SUFFIX = ".epi"

--- a/packages/pipeline/src/pyearthtools/pipeline/step.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/step.py
@@ -13,17 +13,15 @@
 # limitations under the License.
 
 
-from abc import ABCMeta, abstractmethod
-
-from functools import partial
-from typing import Callable, Union, Optional, Literal, Type
 import warnings
+from abc import ABCMeta, abstractmethod
+from functools import partial
+from typing import Callable, Literal, Optional, Type, Union
 
-
-from pyearthtools.pipeline.recording import PipelineRecordingMixin
-from pyearthtools.pipeline.exceptions import PipelineTypeError, PipelineFilterException
-from pyearthtools.pipeline.warnings import PipelineWarning
+from pyearthtools.pipeline.exceptions import PipelineFilterException, PipelineTypeError
 from pyearthtools.pipeline.parallel import ParallelEnabledMixin
+from pyearthtools.pipeline.recording import PipelineRecordingMixin
+from pyearthtools.pipeline.warnings import PipelineWarning
 
 
 class PipelineStep(PipelineRecordingMixin, ParallelEnabledMixin, metaclass=ABCMeta):

--- a/packages/pipeline/src/pyearthtools/pipeline/validation.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/validation.py
@@ -15,7 +15,7 @@
 
 from __future__ import annotations
 
-from typing import Type, Iterable, Optional, Union, Any
+from typing import Any, Iterable, Optional, Type, Union
 
 from pyearthtools.pipeline.exceptions import PipelineTypeError
 

--- a/packages/pipeline/tests/fake_pipeline_steps.py
+++ b/packages/pipeline/tests/fake_pipeline_steps.py
@@ -15,10 +15,8 @@
 from __future__ import annotations
 
 import pyearthtools.utils
-
-from pyearthtools.pipeline import Operation
 from pyearthtools.data import Index
-
+from pyearthtools.pipeline import Operation
 
 pyearthtools.utils.config.set({"pipeline.run_parallel": False})
 

--- a/packages/pipeline/tests/operations/xarray/test_sort.py
+++ b/packages/pipeline/tests/operations/xarray/test_sort.py
@@ -14,7 +14,6 @@
 
 import pytest
 import xarray as xr
-
 from pyearthtools.pipeline.operations.xarray import sort
 
 SIMPLE_DA1 = xr.DataArray(

--- a/packages/pipeline/tests/pipeline/test_controller.py
+++ b/packages/pipeline/tests/pipeline/test_controller.py
@@ -1,5 +1,4 @@
 import pytest
-
 from pyearthtools.pipeline import controller
 
 # def test_PipelineIndex():

--- a/packages/pipeline/tests/pipeline/test_idx_mod.py
+++ b/packages/pipeline/tests/pipeline/test_idx_mod.py
@@ -15,13 +15,10 @@
 
 from __future__ import annotations
 
-import pytest
-
 import pyearthtools.utils
-
-from pyearthtools.pipeline import Pipeline, modifications
-from pyearthtools.pipeline import Operation
+import pytest
 from pyearthtools.data import Index
+from pyearthtools.pipeline import Operation, Pipeline, modifications
 
 
 class FakeIndex(Index):

--- a/packages/pipeline/tests/pipeline/test_idx_mod.py
+++ b/packages/pipeline/tests/pipeline/test_idx_mod.py
@@ -165,20 +165,20 @@ def test_TimeIdxModifier_basic():
     import pyearthtools.data
 
     pipe = Pipeline(FakeIndex(), modifications.TimeIdxModifier("6 hours"))
-    assert pipe[pyearthtools.data.Petdt("2000-01-01T00")] == pyearthtools.data.Petdt("2000-01-01T06")
+    assert pipe[pyearthtools.data.time.Petdt("2000-01-01T00")] == pyearthtools.data.time.Petdt("2000-01-01T06")
 
 
 # def test_TimeIdxModifier_basic_tuple():
 #     import pyearthtools.data
 #     pipe = Pipeline(FakeIndex(), pipelines.TimeIdxModifier((6, 'hours')))
-#     assert pipe[pyearthtools.data.Petdt('2000-01-01T00')] == pyearthtools.data.Petdt('2000-01-01T06')
+#     assert pipe[pyearthtools.data.time.Petdt('2000-01-01T00')] == pyearthtools.data.time.Petdt('2000-01-01T06')
 
 
 def test_TimeIdxModifier_nested():
     import pyearthtools.data
 
     pipe = Pipeline(FakeIndex(), modifications.TimeIdxModifier(("6 hours", "12 hours")))
-    assert pipe[pyearthtools.data.Petdt("2000-01-01T00")] == (
-        pyearthtools.data.Petdt("2000-01-01T06"),
-        pyearthtools.data.Petdt("2000-01-01T12"),
+    assert pipe[pyearthtools.data.time.Petdt("2000-01-01T00")] == (
+        pyearthtools.data.time.Petdt("2000-01-01T06"),
+        pyearthtools.data.time.Petdt("2000-01-01T12"),
     )

--- a/packages/pipeline/tests/pipeline/test_sequence.py
+++ b/packages/pipeline/tests/pipeline/test_sequence.py
@@ -14,22 +14,18 @@
 
 
 from __future__ import annotations
+
 from typing import Any
 
-import pytest
-
 import pyearthtools.utils
+import pytest
 
 pyearthtools.utils.config.set({"pipeline.run_parallel": False})
 
 import pyearthtools.data
-
-from pyearthtools.pipeline import Pipeline, exceptions, modifications
-from pyearthtools.pipeline.modifications.idx_modification import SequenceRetrieval
-
-from pyearthtools.pipeline import Operation
 from pyearthtools.data import Index
-
+from pyearthtools.pipeline import Operation, Pipeline, exceptions, modifications
+from pyearthtools.pipeline.modifications.idx_modification import SequenceRetrieval
 
 pyearthtools.utils.config.set({"pipeline.run_parallel": False})
 

--- a/packages/pipeline/tests/pipeline/test_temporal_idx_mod.py
+++ b/packages/pipeline/tests/pipeline/test_temporal_idx_mod.py
@@ -14,22 +14,18 @@
 
 
 from __future__ import annotations
+
 from typing import Any
 
-import pytest
-
 import pyearthtools.utils
+import pytest
 
 pyearthtools.utils.config.set({"pipeline.run_parallel": False})
 
 import pyearthtools.data
-
-from pyearthtools.pipeline import Pipeline, exceptions
-from pyearthtools.pipeline.modifications.idx_modification import TemporalRetrieval
-
-from pyearthtools.pipeline import Operation
 from pyearthtools.data import Index
-
+from pyearthtools.pipeline import Operation, Pipeline, exceptions
+from pyearthtools.pipeline.modifications.idx_modification import TemporalRetrieval
 
 pyearthtools.utils.config.set({"pipeline.run_parallel": False})
 

--- a/packages/pipeline/tests/test_controller/test_branchpoints.py
+++ b/packages/pipeline/tests/test_controller/test_branchpoints.py
@@ -14,13 +14,14 @@
 
 from __future__ import annotations
 
-import pytest
-
 import pyearthtools.utils
-
-from pyearthtools.pipeline import Pipeline, exceptions, branching
-
-from tests.fake_pipeline_steps import FakeIndex, MultiplicationOperation, MultiplicationOperationUnunifiedable
+import pytest
+from pyearthtools.pipeline import Pipeline, branching, exceptions
+from tests.fake_pipeline_steps import (
+    FakeIndex,
+    MultiplicationOperation,
+    MultiplicationOperationUnunifiedable,
+)
 
 pyearthtools.utils.config.set({"pipeline.run_parallel": False})
 

--- a/packages/pipeline/tests/test_controller/test_joining.py
+++ b/packages/pipeline/tests/test_controller/test_joining.py
@@ -13,14 +13,12 @@
 # limitations under the License.
 
 from __future__ import annotations
+
 from typing import Any
 
-import pytest
-
 import pyearthtools.utils
-
+import pytest
 from pyearthtools.pipeline import Pipeline, branching
-
 from tests.fake_pipeline_steps import FakeIndex, MultiplicationOperation
 
 pyearthtools.utils.config.set({"pipeline.run_parallel": False})

--- a/packages/pipeline/tests/test_controller/test_split.py
+++ b/packages/pipeline/tests/test_controller/test_split.py
@@ -15,12 +15,9 @@
 
 from __future__ import annotations
 
-import pytest
-
 import pyearthtools.utils
-
+import pytest
 from pyearthtools.pipeline import Pipeline, branching
-
 from tests.fake_pipeline_steps import FakeIndex
 
 pyearthtools.utils.config.set({"pipeline.run_parallel": False})

--- a/packages/pipeline/tests/test_controller/test_unify.py
+++ b/packages/pipeline/tests/test_controller/test_unify.py
@@ -14,12 +14,9 @@
 
 from __future__ import annotations
 
-import pytest
-
 import pyearthtools.utils
-
+import pytest
 from pyearthtools.pipeline import Pipeline, branching, exceptions
-
 from tests.fake_pipeline_steps import FakeIndex
 
 pyearthtools.utils.config.set({"pipeline.run_parallel": False})

--- a/packages/pipeline/tests/test_filters.py
+++ b/packages/pipeline/tests/test_filters.py
@@ -13,12 +13,10 @@
 # limitations under the License.
 
 
-import pytest
-
-from pyearthtools.pipeline import Pipeline, iterators, filters, exceptions, Operation
-from pyearthtools.data import Index
-
 import pyearthtools.utils
+import pytest
+from pyearthtools.data import Index
+from pyearthtools.pipeline import Operation, Pipeline, exceptions, filters, iterators
 
 pyearthtools.utils.config.set({"pipeline.run_parallel": False})
 

--- a/packages/pipeline/tests/test_iteration.py
+++ b/packages/pipeline/tests/test_iteration.py
@@ -14,7 +14,6 @@
 
 
 import pytest
-
 from pyearthtools.pipeline import Pipeline, iterators, samplers
 from tests.fake_pipeline_steps import FakeIndex
 

--- a/packages/pipeline/tests/test_operation/test_recognised_types.py
+++ b/packages/pipeline/tests/test_operation/test_recognised_types.py
@@ -14,9 +14,8 @@
 
 
 import pytest
-from pyearthtools.pipeline import Operation, Pipeline
-
 from pyearthtools.data import Index
+from pyearthtools.pipeline import Operation, Pipeline
 
 
 class FakeIndex(Index):

--- a/packages/training/src/pyearthtools/training/__init__.py
+++ b/packages/training/src/pyearthtools/training/__init__.py
@@ -21,12 +21,11 @@ and allow rapid distributed training of Machine Learning Models.
 """
 # ruff: noqa: F401
 
+from pyearthtools.training import data
 from pyearthtools.training import logger as _
-
-from pyearthtools.training import data, wrapper, manage
-
-from pyearthtools.training.wrapper import *  # type: ignore # noqa: F403
+from pyearthtools.training import manage, wrapper
 from pyearthtools.training.dataindex import MLDataIndex
+from pyearthtools.training.wrapper import *  # type: ignore # noqa: F403
 
 __version__ = "0.1.0"
 

--- a/packages/training/src/pyearthtools/training/commands.py
+++ b/packages/training/src/pyearthtools/training/commands.py
@@ -18,8 +18,9 @@ pyearthtools Trainer Commands
 """
 from __future__ import annotations
 
-import click
 import sys
+
+import click
 
 
 @click.group(name="Trainer From Yaml")

--- a/packages/training/src/pyearthtools/training/data/__init__.py
+++ b/packages/training/src/pyearthtools/training/data/__init__.py
@@ -15,13 +15,11 @@
 
 # ruff: noqa: F401
 
-from pyearthtools.training.data.datamodule import PipelineDataModule
+import logging
 
 from pyearthtools.training.data import default
-
-from pyearthtools.training.data.fileio import save, load
-
-import logging
+from pyearthtools.training.data.datamodule import PipelineDataModule
+from pyearthtools.training.data.fileio import load, save
 
 LOG = logging.getLogger(__name__)
 try:

--- a/packages/training/src/pyearthtools/training/data/datamodule.py
+++ b/packages/training/src/pyearthtools/training/data/datamodule.py
@@ -20,15 +20,13 @@ Training DataModule to source data from `pipeline`'s.
 from __future__ import annotations
 
 import functools
-from typing import Optional, Callable, Any, TypeVar
+from pathlib import Path
+from typing import Any, Callable, Optional, TypeVar
 
 import numpy as np
-from pathlib import Path
-
 import pyearthtools.pipeline
-from pyearthtools.pipeline import Pipeline, Iterator
+from pyearthtools.pipeline import Iterator, Pipeline
 from pyearthtools.utils.initialisation import InitialisationRecordingMixin
-
 
 CONFIG_KEY = "--CONFIG--"
 SUFFIX = ".datamodule"

--- a/packages/training/src/pyearthtools/training/data/default/__init__.py
+++ b/packages/training/src/pyearthtools/training/data/default/__init__.py
@@ -20,5 +20,11 @@ Default DataModules
 
 # ruff: noqa: F401
 
-from pyearthtools.training.data.default.datamodule import PipelineDefaultDataModule, DataLoader
-from pyearthtools.training.data.default.datasets import IndexableDataset, IterableDataset
+from pyearthtools.training.data.default.datamodule import (
+    DataLoader,
+    PipelineDefaultDataModule,
+)
+from pyearthtools.training.data.default.datasets import (
+    IndexableDataset,
+    IterableDataset,
+)

--- a/packages/training/src/pyearthtools/training/data/default/datamodule.py
+++ b/packages/training/src/pyearthtools/training/data/default/datamodule.py
@@ -14,17 +14,20 @@
 
 
 from __future__ import annotations
+
 import functools
-from typing import Callable, Any
+from typing import Any, Callable
 
 import numpy as np
 import xarray as xr
-
 from pyearthtools.pipeline.controller import Pipeline
 from pyearthtools.pipeline.iterators import Iterator
-
 from pyearthtools.training.data.datamodule import PipelineDataModule
-from pyearthtools.training.data.default.datasets import IndexableDataset, IterableDataset, BaseDefault
+from pyearthtools.training.data.default.datasets import (
+    BaseDefault,
+    IndexableDataset,
+    IterableDataset,
+)
 
 
 def map_function(obj, function: Callable[[Any], Any], **kwargs):

--- a/packages/training/src/pyearthtools/training/data/fileio.py
+++ b/packages/training/src/pyearthtools/training/data/fileio.py
@@ -15,15 +15,14 @@
 
 from __future__ import annotations
 
-from typing import Optional, Any
 import os
-
 from pathlib import Path
-import yaml
+from typing import Any, Optional
 
 import pyearthtools.pipeline
-from pyearthtools.utils.initialisation import Dumper, Loader, update_contents
+import yaml
 from pyearthtools.training.data.datamodule import PipelineDataModule
+from pyearthtools.utils.initialisation import Dumper, Loader, update_contents
 
 CONFIG_KEY = "--CONFIG--"
 SUFFIX = ".edm"

--- a/packages/training/src/pyearthtools/training/data/lightning/__init__.py
+++ b/packages/training/src/pyearthtools/training/data/lightning/__init__.py
@@ -16,4 +16,7 @@
 # ruff: noqa: F401
 
 from pyearthtools.training.data.lightning.datamodule import PipelineLightningDataModule
-from pyearthtools.training.data.lightning.datasets import PytorchDataset, PytorchIterable
+from pyearthtools.training.data.lightning.datasets import (
+    PytorchDataset,
+    PytorchIterable,
+)

--- a/packages/training/src/pyearthtools/training/data/lightning/datamodule.py
+++ b/packages/training/src/pyearthtools/training/data/lightning/datamodule.py
@@ -15,16 +15,17 @@
 
 from __future__ import annotations
 
-
 import lightning as L
 from lightning.pytorch.utilities import CombinedLoader
-from torch.utils.data import DataLoader
-
 from pyearthtools.pipeline.controller import Pipeline
 from pyearthtools.pipeline.iterators import Iterator
-
 from pyearthtools.training.data.datamodule import PipelineDataModule
-from pyearthtools.training.data.lightning.datasets import PytorchDataset, PytorchIterable, BasePytorchPipeline
+from pyearthtools.training.data.lightning.datasets import (
+    BasePytorchPipeline,
+    PytorchDataset,
+    PytorchIterable,
+)
+from torch.utils.data import DataLoader
 
 
 class PipelineLightningDataModule(PipelineDataModule, L.LightningDataModule):

--- a/packages/training/src/pyearthtools/training/data/lightning/datasets.py
+++ b/packages/training/src/pyearthtools/training/data/lightning/datasets.py
@@ -15,10 +15,9 @@
 
 from __future__ import annotations
 
-from torch.utils.data import IterableDataset, get_worker_info, Dataset
-
 import pyearthtools
 from pyearthtools.pipeline import Pipeline
+from torch.utils.data import Dataset, IterableDataset, get_worker_info
 
 
 class BasePytorchPipeline:

--- a/packages/training/src/pyearthtools/training/dataindex.py
+++ b/packages/training/src/pyearthtools/training/dataindex.py
@@ -21,17 +21,15 @@ This will allow data to be retrieved as normal, with the user not having to worr
 from __future__ import annotations
 
 import os
-
 from pathlib import Path
-import yaml
 from typing import Any
 
 import pyearthtools.data
-from pyearthtools.data import Petdt, Transform, TransformCollection, TimeDelta
+import pyearthtools.training.wrapper
+import yaml
+from pyearthtools.data import Petdt, TimeDelta, Transform, TransformCollection
 from pyearthtools.data.indexes import TimeIndex
 from pyearthtools.data.indexes.cacheIndex import BaseCacheIndex
-
-import pyearthtools.training.wrapper
 
 ATTRIBUTE_MARK = pyearthtools.data.transforms.attributes.set_attributes(
     purpose="Research Use Only.",

--- a/packages/training/src/pyearthtools/training/manage.py
+++ b/packages/training/src/pyearthtools/training/manage.py
@@ -4,11 +4,12 @@ Variable management
 """
 
 from __future__ import annotations
-from typing import Any, overload, Union, Optional, Callable, TypeVar
 
-import xarray as xr
-import numpy as np
 import itertools
+from typing import Any, Callable, Optional, TypeVar, Union, overload
+
+import numpy as np
+import xarray as xr
 
 TORCH_INSTALLED = True
 try:

--- a/packages/training/src/pyearthtools/training/modules/loss/__init__.py
+++ b/packages/training/src/pyearthtools/training/modules/loss/__init__.py
@@ -15,13 +15,12 @@
 
 import importlib
 
-from pyearthtools.training.modules.loss.extremes import ExtremeLoss
+from pyearthtools.training import modules
 from pyearthtools.training.modules.loss.centre_weighted import centre_weighted
+from pyearthtools.training.modules.loss.component import ComponentLoss
+from pyearthtools.training.modules.loss.extremes import ExtremeLoss
 from pyearthtools.training.modules.loss.rmse import RMSELoss
 from pyearthtools.training.modules.loss.structure import SSIMLoss
-from pyearthtools.training.modules.loss.component import ComponentLoss
-
-from pyearthtools.training import modules
 
 
 def _get_callable(module: str):

--- a/packages/training/src/pyearthtools/training/modules/loss/centre_weighted.py
+++ b/packages/training/src/pyearthtools/training/modules/loss/centre_weighted.py
@@ -14,11 +14,12 @@
 
 
 import functools
+import math
 from typing import Callable, Union
-from torch import nn
+
 import numpy as np
 import torch
-import math
+from torch import nn
 
 
 def sin(m_adjust=1, drop_rate=0.5, dimensions: tuple[int] = [-2, -1]):

--- a/packages/training/src/pyearthtools/training/modules/loss/component.py
+++ b/packages/training/src/pyearthtools/training/modules/loss/component.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 
-from torch import nn
-import torch
 import pyearthtools.training
+import torch
+from torch import nn
 
 
 class ComponentLoss(nn.Module):

--- a/packages/training/src/pyearthtools/training/modules/loss/structure.py
+++ b/packages/training/src/pyearthtools/training/modules/loss/structure.py
@@ -13,10 +13,9 @@
 # limitations under the License.
 
 
+import einops
 import torch
 from piqa import SSIM
-
-import einops
 
 
 class SSIMLoss(torch.nn.Module):

--- a/packages/training/src/pyearthtools/training/wrapper/__init__.py
+++ b/packages/training/src/pyearthtools/training/wrapper/__init__.py
@@ -16,12 +16,10 @@
 # ruff: noqa: F401
 
 
-from pyearthtools.training.wrapper.wrapper import ModelWrapper
-
 from pyearthtools.training.wrapper import predict, train, utils
-
-from pyearthtools.training.wrapper.train import TrainingWrapper
 from pyearthtools.training.wrapper.predict import Predictor
+from pyearthtools.training.wrapper.train import TrainingWrapper
+from pyearthtools.training.wrapper.wrapper import ModelWrapper
 
 try:
     ONNX_IMPORTED = True

--- a/packages/training/src/pyearthtools/training/wrapper/lightning/__init__.py
+++ b/packages/training/src/pyearthtools/training/wrapper/lightning/__init__.py
@@ -19,5 +19,7 @@
 Pytorch Lighting Wrappers
 """
 
-from pyearthtools.training.wrapper.lightning.predict import LightingPrediction as Predict
+from pyearthtools.training.wrapper.lightning.predict import (
+    LightingPrediction as Predict,
+)
 from pyearthtools.training.wrapper.lightning.train import LightingTraining as Train

--- a/packages/training/src/pyearthtools/training/wrapper/lightning/predict.py
+++ b/packages/training/src/pyearthtools/training/wrapper/lightning/predict.py
@@ -15,17 +15,14 @@
 
 from __future__ import annotations
 
-from functools import cached_property
 import logging
 import warnings
-
+from functools import cached_property
 from typing import Any
 
-import numpy as np
 import lightning as L
-
+import numpy as np
 from pyearthtools.data.patterns.utils import parse_root_dir
-
 from pyearthtools.pipeline.controller import Pipeline
 from pyearthtools.training.data.lightning import PipelineLightningDataModule
 from pyearthtools.training.wrapper.lightning.wrapper import LightningWrapper

--- a/packages/training/src/pyearthtools/training/wrapper/lightning/train.py
+++ b/packages/training/src/pyearthtools/training/wrapper/lightning/train.py
@@ -14,16 +14,14 @@
 
 from __future__ import annotations
 
+import importlib.util
 import os
+import warnings
 from pathlib import Path
 from typing import Any, Optional
-import warnings
-import importlib.util
 
 import lightning as L
-from lightning.pytorch import callbacks
-from lightning.pytorch import loggers
-
+from lightning.pytorch import callbacks, loggers
 from pyearthtools.pipeline.controller import Pipeline
 from pyearthtools.training.data.lightning import PipelineLightningDataModule
 from pyearthtools.training.wrapper.lightning.wrapper import LightningWrapper

--- a/packages/training/src/pyearthtools/training/wrapper/lightning/wrapper.py
+++ b/packages/training/src/pyearthtools/training/wrapper/lightning/wrapper.py
@@ -14,15 +14,14 @@
 
 
 from __future__ import annotations
+
+import warnings
 from pathlib import Path
 from typing import Any, Optional
-import warnings
 
 import lightning as L
 import torch
-
 from pyearthtools.data.utils import parse_path
-
 from pyearthtools.pipeline.controller import Pipeline
 from pyearthtools.training.data.lightning import PipelineLightningDataModule
 from pyearthtools.training.wrapper.wrapper import ModelWrapper

--- a/packages/training/src/pyearthtools/training/wrapper/onnx.py
+++ b/packages/training/src/pyearthtools/training/wrapper/onnx.py
@@ -15,17 +15,14 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 import logging
+from pathlib import Path
 from typing import Optional
 
 import onnxruntime as ort
-
 from pyearthtools.pipeline.controller import Pipeline
-
-from pyearthtools.training.wrapper.wrapper import ModelWrapper
 from pyearthtools.training.data.datamodule import PipelineDataModule
-
+from pyearthtools.training.wrapper.wrapper import ModelWrapper
 
 LOG = logging.getLogger(__name__)
 

--- a/packages/training/src/pyearthtools/training/wrapper/predict/__init__.py
+++ b/packages/training/src/pyearthtools/training/wrapper/predict/__init__.py
@@ -19,15 +19,14 @@
 Prediction Wrappers
 """
 
-from pyearthtools.utils.decorators import BackwardsCompatibility
-
 from pyearthtools.training.wrapper.predict.predict import Predictor
 from pyearthtools.training.wrapper.predict.timeseries import (
-    TimeSeriesPredictor,
+    ManualTimeSeriesPredictor,
     TimeSeriesAutoRecurrentPredictor,
     TimeSeriesManagedPredictor,
-    ManualTimeSeriesPredictor,
+    TimeSeriesPredictor,
 )
+from pyearthtools.utils.decorators import BackwardsCompatibility
 
 
 @BackwardsCompatibility(TimeSeriesPredictor)

--- a/packages/training/src/pyearthtools/training/wrapper/predict/coupled.py
+++ b/packages/training/src/pyearthtools/training/wrapper/predict/coupled.py
@@ -14,22 +14,19 @@
 
 
 from __future__ import annotations
+
 import functools
-
-from typing import Literal, TypeVar, Any, Optional
-
 from abc import abstractmethod
+from typing import Any, Literal, Optional, TypeVar
 
-from pyearthtools.data.time import TimeDelta
-import xarray as xr
 import numpy as np
 import tqdm.auto as tqdm
-
+import xarray as xr
+from pyearthtools.data.time import TimeDelta
 from pyearthtools.pipeline.controller import Pipeline
-from pyearthtools.training.wrapper.wrapper import ModelWrapper
-from pyearthtools.training.wrapper.predict.timeseries import TimeSeriesPredictor
-
 from pyearthtools.training.manage import Variables
+from pyearthtools.training.wrapper.predict.timeseries import TimeSeriesPredictor
+from pyearthtools.training.wrapper.wrapper import ModelWrapper
 
 XR_TYPE = TypeVar("XR_TYPE", xr.Dataset, xr.DataArray)
 

--- a/packages/training/src/pyearthtools/training/wrapper/predict/predict.py
+++ b/packages/training/src/pyearthtools/training/wrapper/predict/predict.py
@@ -15,15 +15,12 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from abc import ABCMeta
-
-
-from pyearthtools.utils.initialisation import InitialisationRecordingMixin
+from typing import Any
 
 from pyearthtools.pipeline.controller import Pipeline
 from pyearthtools.training.wrapper.wrapper import ModelWrapper
+from pyearthtools.utils.initialisation import InitialisationRecordingMixin
 
 
 class Predictor(InitialisationRecordingMixin, metaclass=ABCMeta):

--- a/packages/training/src/pyearthtools/training/wrapper/predict/timeseries.py
+++ b/packages/training/src/pyearthtools/training/wrapper/predict/timeseries.py
@@ -14,25 +14,20 @@
 
 
 from __future__ import annotations
+
 import functools
-
-from typing import Literal, TypeVar, Any, Optional
-
+import logging
 from abc import abstractmethod
+from typing import Any, Literal, Optional, TypeVar
 
-import xarray as xr
 import numpy as np
 import tqdm.auto as tqdm
-import logging
-
-
-from pyearthtools.data import TimeDelta, Petdt, TimeRange
-
+import xarray as xr
+from pyearthtools.data import Petdt, TimeDelta, TimeRange
 from pyearthtools.pipeline.controller import Pipeline
-from pyearthtools.training.wrapper.wrapper import ModelWrapper
-from pyearthtools.training.wrapper.predict.predict import Predictor
-
 from pyearthtools.training.manage import Variables
+from pyearthtools.training.wrapper.predict.predict import Predictor
+from pyearthtools.training.wrapper.wrapper import ModelWrapper
 
 XR_TYPE = TypeVar("XR_TYPE", xr.Dataset, xr.DataArray)
 LOG = logging.getLogger("pyearthtools.training")

--- a/packages/training/src/pyearthtools/training/wrapper/predict/timeseries.py
+++ b/packages/training/src/pyearthtools/training/wrapper/predict/timeseries.py
@@ -78,7 +78,7 @@ class TimeSeriesPredictor(Predictor):
             fix_time_dim (bool, optional):
                 Fix time dimension after prediction. Defaults to True.
             interval (int | str | TimeDelta, optional):
-                Interval of temporal predictions, must be passable by `pyearthtools.data.TimeDelta`. Defaults to 1.
+                Interval of temporal predictions, must be passable by `pyearthtools.data.time.TimeDelta`. Defaults to 1.
             time_dim (str, optional):
                 Name of time dimension in undone data. Defaults to "time".
         """
@@ -209,7 +209,7 @@ class TimeSeriesAutoRecurrentPredictor(TimeSeriesPredictor):
             fix_time_dim (bool, optional):
                 Fix time dimension after prediction. Defaults to True.
             interval (int | str | TimeDelta, optional):
-                Interval of temporal predictions, must be passable by `pyearthtools.data.TimeDelta`. Defaults to 1.
+                Interval of temporal predictions, must be passable by `pyearthtools.data.time.TimeDelta`. Defaults to 1.
             time_dim (str, optional):
                 Name of time dimension in undone data. Defaults to "time".
             combine (Optional[Literal['stack', 'combine']], optional):

--- a/packages/training/src/pyearthtools/training/wrapper/utils.py
+++ b/packages/training/src/pyearthtools/training/wrapper/utils.py
@@ -14,12 +14,12 @@
 
 
 from __future__ import annotations
+
 import functools
-
-from typing import Callable
 import math
+from typing import Callable
 
-from pyearthtools.data import TimeDelta, Petdt
+from pyearthtools.data import Petdt, TimeDelta
 
 
 def parse_recurrent(interval: int | TimeDelta = 1):

--- a/packages/training/src/pyearthtools/training/wrapper/wrapper.py
+++ b/packages/training/src/pyearthtools/training/wrapper/wrapper.py
@@ -16,10 +16,9 @@ from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
 
-from pyearthtools.utils.initialisation import InitialisationRecordingMixin
 from pyearthtools.pipeline import Pipeline
-
 from pyearthtools.training.data import PipelineDataModule
+from pyearthtools.utils.initialisation import InitialisationRecordingMixin
 
 
 class ModelWrapper(InitialisationRecordingMixin, metaclass=ABCMeta):

--- a/packages/tutorial/src/pyearthtools/tutorial/ERA5DataClass.py
+++ b/packages/tutorial/src/pyearthtools/tutorial/ERA5DataClass.py
@@ -28,20 +28,19 @@ An indexer takes some
 from __future__ import annotations
 
 import functools
-
 from pathlib import Path
 from typing import Any, Literal
 
-
 import pyearthtools.data
-
 from pyearthtools.data import Petdt
+from pyearthtools.data.archive import register_archive
 from pyearthtools.data.exceptions import DataNotFoundError
 from pyearthtools.data.indexes import ArchiveIndex, decorators
 from pyearthtools.data.transforms import Transform, TransformCollection
-from pyearthtools.data.archive import register_archive
-
-from pyearthtools.tutorial.ancilliary.ERA5lowres import ERA5_SINGLE_VARIABLES, ERA5_PRESSURE_VARIABLES
+from pyearthtools.tutorial.ancilliary.ERA5lowres import (
+    ERA5_PRESSURE_VARIABLES,
+    ERA5_SINGLE_VARIABLES,
+)
 
 # This tells pyearthtools what the actual resolution or time-step of the data is inside the files
 ERA_RESOLUTION = (1, "hour")

--- a/packages/utils/src/pyearthtools/utils/__init__.py
+++ b/packages/utils/src/pyearthtools/utils/__init__.py
@@ -22,14 +22,19 @@ pyearthtools Utilities
 __version__ = "0.1.0"
 
 import importlib
-
-from pyearthtools.utils import parameter, repr_utils, context, decorators, initialisation, config, logger
-from pyearthtools.utils.initialisation import load, save, dynamic_import
-
-
-import pyearthtools
 import importlib.util
 
-from pyearthtools.utils import data
+import pyearthtools
+from pyearthtools.utils import (
+    config,
+    context,
+    data,
+    decorators,
+    initialisation,
+    logger,
+    parameter,
+    repr_utils,
+)
+from pyearthtools.utils.initialisation import dynamic_import, load, save
 
 setattr(pyearthtools, "config", config)

--- a/packages/utils/src/pyearthtools/utils/context.py
+++ b/packages/utils/src/pyearthtools/utils/context.py
@@ -17,10 +17,10 @@
 Contexts
 """
 from __future__ import annotations
-from typing import Any, Type, Callable
-import logging
 
+import logging
 from contextlib import ContextDecorator
+from typing import Any, Callable, Type
 
 
 class ChangeValue(ContextDecorator):

--- a/packages/utils/src/pyearthtools/utils/data/__init__.py
+++ b/packages/utils/src/pyearthtools/utils/data/__init__.py
@@ -17,5 +17,5 @@
 Common Data tools
 """
 
-from pyearthtools.utils.data.tesselator import Tesselator
 from pyearthtools.utils.data import converter
+from pyearthtools.utils.data.tesselator import Tesselator

--- a/packages/utils/src/pyearthtools/utils/data/converter.py
+++ b/packages/utils/src/pyearthtools/utils/data/converter.py
@@ -17,17 +17,15 @@
 
 
 from __future__ import annotations
-from abc import ABCMeta, abstractmethod
-import importlib.util
-import json
-from pathlib import Path
-from typing import Any, Union, Literal
-
-from collections import OrderedDict
-import warnings
 
 import importlib
-
+import importlib.util
+import json
+import warnings
+from abc import ABCMeta, abstractmethod
+from collections import OrderedDict
+from pathlib import Path
+from typing import Any, Literal, Union
 
 import numpy as np
 import xarray as xr

--- a/packages/utils/src/pyearthtools/utils/data/tesselator/__init__.py
+++ b/packages/utils/src/pyearthtools/utils/data/tesselator/__init__.py
@@ -20,15 +20,14 @@ Provides ways to split data into patches, and reform patches back to full data
 """
 from __future__ import annotations
 
-from typing import Union
 import warnings
+from typing import Union
 
 import numpy as np
 import xarray as xr
-
 from pyearthtools.utils.data.tesselator import _patching
-from pyearthtools.utils.warnings import TesselatorWarning
 from pyearthtools.utils.exceptions import TesselatorException
+from pyearthtools.utils.warnings import TesselatorWarning
 
 
 class Tesselator:

--- a/packages/utils/src/pyearthtools/utils/data/tesselator/_patching/patches.py
+++ b/packages/utils/src/pyearthtools/utils/data/tesselator/_patching/patches.py
@@ -23,14 +23,13 @@ from typing import Optional, Union
 
 import numpy as np
 import xarray as xr
-
 from pyearthtools.utils.data.tesselator._patching import (
     DEFAULT_FORMAT_PATCH,
     DEFAULT_FORMAT_PATCH_AFTER,
     DEFAULT_FORMAT_PATCH_ORGANISE,
 )
 from pyearthtools.utils.data.tesselator._patching.reorder import reorder
-from pyearthtools.utils.data.tesselator._patching.subset import cut_center, center
+from pyearthtools.utils.data.tesselator._patching.subset import center, cut_center
 
 
 def factors(value: int) -> list[list[int, int]]:

--- a/packages/utils/src/pyearthtools/utils/data/tesselator/_patching/reorder.py
+++ b/packages/utils/src/pyearthtools/utils/data/tesselator/_patching/reorder.py
@@ -18,7 +18,6 @@ Reorder Data
 """
 from __future__ import annotations
 
-
 import numpy as np
 
 

--- a/packages/utils/src/pyearthtools/utils/data/tesselator/_patching/subset.py
+++ b/packages/utils/src/pyearthtools/utils/data/tesselator/_patching/subset.py
@@ -23,10 +23,9 @@ import math
 from typing import Iterable, Union
 
 import numpy as np
-
-from pyearthtools.utils.exceptions import TesselatorException
 from pyearthtools.utils.data.tesselator._patching import DEFAULT_FORMAT_SUBSET
 from pyearthtools.utils.data.tesselator._patching.reorder import move_to_end, reorder
+from pyearthtools.utils.exceptions import TesselatorException
 
 
 def cut_center(data: np.ndarray, size: Union[int, tuple[int, int]]) -> np.ndarray:

--- a/packages/utils/src/pyearthtools/utils/decorators.py
+++ b/packages/utils/src/pyearthtools/utils/decorators.py
@@ -16,9 +16,8 @@
 from __future__ import annotations
 
 import functools
-from typing import Any, Callable
-
 import warnings
+from typing import Any, Callable
 
 
 class classproperty(property):

--- a/packages/utils/src/pyearthtools/utils/iPython.py
+++ b/packages/utils/src/pyearthtools/utils/iPython.py
@@ -14,9 +14,8 @@
 
 
 import numpy as np
-
-from PIL.Image import fromarray
 from IPython import get_ipython
+from PIL.Image import fromarray
 
 
 def display_np_arrays_as_images():

--- a/packages/utils/src/pyearthtools/utils/initialisation/__init__.py
+++ b/packages/utils/src/pyearthtools/utils/initialisation/__init__.py
@@ -18,11 +18,10 @@ Initialisation recording, saving and loading
 """
 
 
-from pyearthtools.utils.initialisation.mixin import InitialisationRecordingMixin
-from pyearthtools.utils.initialisation.load import load, save, update_contents
-from pyearthtools.utils.initialisation.yaml import Loader, Dumper
-
 from pyearthtools.utils.initialisation.imports import dynamic_import
+from pyearthtools.utils.initialisation.load import load, save, update_contents
+from pyearthtools.utils.initialisation.mixin import InitialisationRecordingMixin
+from pyearthtools.utils.initialisation.yaml import Dumper, Loader
 
 OVERRIDE_KEY = "_pyearthtools_initialisation"
 

--- a/packages/utils/src/pyearthtools/utils/initialisation/imports.py
+++ b/packages/utils/src/pyearthtools/utils/initialisation/imports.py
@@ -19,10 +19,9 @@ Load Classes from dictionary or strings
 
 
 from __future__ import annotations
+
 import builtins
-
 import importlib
-
 from types import ModuleType
 from typing import Callable
 

--- a/packages/utils/src/pyearthtools/utils/initialisation/init_parsing.py
+++ b/packages/utils/src/pyearthtools/utils/initialisation/init_parsing.py
@@ -21,22 +21,22 @@
 # See https://github.com/Lightning-AI/pytorch-lightning/blob/master/src/lightning/pytorch/utilities/parsing.py
 
 
-from collections import OrderedDict
+import inspect
 import types
+from collections import OrderedDict
 from typing import (
     Any,
     Dict,
     List,
     Literal,
+    Mapping,
     MutableMapping,
     Optional,
     Sequence,
     Tuple,
     Type,
     Union,
-    Mapping,
 )
-import inspect
 
 
 class InitialisationRecord(Mapping):

--- a/packages/utils/src/pyearthtools/utils/initialisation/load.py
+++ b/packages/utils/src/pyearthtools/utils/initialisation/load.py
@@ -15,15 +15,13 @@
 
 """Loading utils"""
 
-import os
-from typing import Any, Union, Optional
-
-from pathlib import Path
-import re
-
 import logging
-import yaml
+import os
+import re
+from pathlib import Path
+from typing import Any, Optional, Union
 
+import yaml
 from pyearthtools.utils.initialisation.yaml import Dumper, Loader
 
 LOG = logging.getLogger("pyearthtools.utils")

--- a/packages/utils/src/pyearthtools/utils/initialisation/mixin.py
+++ b/packages/utils/src/pyearthtools/utils/initialisation/mixin.py
@@ -14,8 +14,7 @@
 
 
 import copy
-from typing import Literal, Sequence, Any, Optional, TypeVar
-
+from typing import Any, Literal, Optional, Sequence, TypeVar
 
 import pyearthtools.utils
 from pyearthtools.utils.initialisation import init_parsing

--- a/packages/utils/src/pyearthtools/utils/initialisation/yaml.py
+++ b/packages/utils/src/pyearthtools/utils/initialisation/yaml.py
@@ -13,13 +13,12 @@
 # limitations under the License.
 
 
-from typing import Literal, Sequence, Any, Union, Optional, TypeVar
 from collections.abc import Mapping
-
 from pathlib import Path
-import yaml
+from typing import Any, Literal, Optional, Sequence, TypeVar, Union
 
 import pyearthtools.utils
+import yaml
 from pyearthtools.utils.initialisation.imports import dynamic_import
 from pyearthtools.utils.initialisation.mixin import InitialisationRecordingMixin
 

--- a/packages/utils/src/pyearthtools/utils/logger.py
+++ b/packages/utils/src/pyearthtools/utils/logger.py
@@ -15,15 +15,15 @@
 
 from __future__ import annotations
 
-import os
-import socket
+import datetime as dt
 import logging
 import logging.handlers
+import os
+import socket
 from typing import Literal
-import datetime as dt
+
 import yaml
 from pyearthtools.utils import config
-
 
 LOGGING_LEVELS = Literal["CRITICAL", "FATAL", "ERROR", "WARN", "WARNING", "INFO", "DEBUG", "NOTSET"]
 

--- a/packages/utils/src/pyearthtools/utils/parameter.py
+++ b/packages/utils/src/pyearthtools/utils/parameter.py
@@ -19,11 +19,11 @@ Function parameter searching
 
 """
 
+import concurrent.futures
 import itertools
 from typing import Callable
-import tqdm.auto as tqdm
 
-import concurrent.futures
+import tqdm.auto as tqdm
 
 _executor = concurrent.futures.ThreadPoolExecutor()
 

--- a/packages/utils/src/pyearthtools/utils/parsing/names.py
+++ b/packages/utils/src/pyearthtools/utils/parsing/names.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 
-from typing import Callable
 import types
+from typing import Callable
 
 
 def function_name(object: Callable) -> str:

--- a/packages/utils/src/pyearthtools/utils/repr_utils/__init__.py
+++ b/packages/utils/src/pyearthtools/utils/repr_utils/__init__.py
@@ -15,5 +15,4 @@
 
 from .html import provide_html
 from .html import provide_html as html
-
 from .standard import provide_repr as default

--- a/packages/utils/src/pyearthtools/utils/repr_utils/standard.py
+++ b/packages/utils/src/pyearthtools/utils/repr_utils/standard.py
@@ -13,9 +13,8 @@
 # limitations under the License.
 
 
-from typing import Optional
-
 import copy
+from typing import Optional
 
 
 def dynamic_padding(name, length_):

--- a/packages/utils/tests/pyearthtools/utils/data/tesselator/test_reorder.py
+++ b/packages/utils/tests/pyearthtools/utils/data/tesselator/test_reorder.py
@@ -1,6 +1,11 @@
 import numpy as np
 import pytest
-from pyearthtools.utils.data.tesselator._patching.reorder import setup_formats, reorder, move_to_end
+from pyearthtools.utils.data.tesselator._patching.reorder import (
+    move_to_end,
+    reorder,
+    setup_formats,
+)
+
 
 # Test setup_formats function.
 def test_setup_formats():

--- a/packages/utils/tests/pyearthtools/utils/data/tesselator/test_subset.py
+++ b/packages/utils/tests/pyearthtools/utils/data/tesselator/test_subset.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-from pyearthtools.utils.data.tesselator._patching.subset import cut_center, center
+from pyearthtools.utils.data.tesselator._patching.subset import center, cut_center
 from pyearthtools.utils.exceptions import TesselatorException
 
 

--- a/packages/utils/tests/pyearthtools/utils/data/tesselator/test_tesselator.py
+++ b/packages/utils/tests/pyearthtools/utils/data/tesselator/test_tesselator.py
@@ -14,9 +14,7 @@
 
 
 import numpy as np
-
 import pytest
-
 from pyearthtools.utils.data import Tesselator
 
 tesselator_tests = [

--- a/packages/utils/tests/pyearthtools/utils/data/test_converter.py
+++ b/packages/utils/tests/pyearthtools/utils/data/test_converter.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 
-from pyearthtools.utils.data import converter
-import xarray as xr
 import pytest
+import xarray as xr
+from pyearthtools.utils.data import converter
 
 SIMPLE_DATA_ARRAY = xr.DataArray([1, 2, 3, 4, 5])
 SIMPLE_DATA_SET = xr.Dataset({"Entry": SIMPLE_DATA_ARRAY})

--- a/packages/utils/tests/pyearthtools/utils/parsing/test_names.py
+++ b/packages/utils/tests/pyearthtools/utils/parsing/test_names.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pyearthtools.utils.parsing import names
 import pyearthtools.utils.parameter
+from pyearthtools.utils.parsing import names
 
 
 def test_function_name():


### PR DESCRIPTION
Fix resultant circular import issues

I ran isort and black
Instead of importing from the API as defined in __init__.py, I imported things directly out of the fully-qualified namespace for the path they were actually declared in
I'm not sure if this was the best approach but it worked fine


