### PR TITLE
Removed .core from pipeline.controller IPython.core.display import to…

### DIFF
--- a/packages/pipeline/src/pyearthtools/pipeline/controller.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/controller.py
@@ -773,7 +773,7 @@ class Pipeline(_Pipeline, Index):
 
     def _ipython_display_(self):
         """Override for repr of `Pipeline`, shows initialisation arguments and graph"""
-        from IPython.core.display import display, HTML
+        from IPython.display import display, HTML
 
         display(HTML(self._repr_html_()))
 


### PR DESCRIPTION
… fix graph display issue in notebooks.

When running the notebooks I experienced an issue importing display from IPython (logged as an issue: https://github.com/ACCESS-Community-Hub/PyEarthTools/issues/70)

Removing .core from the import resolves this issue and enables display to import and display the graphs in the tutorial notebooks. 