### PR TITLE
Docstring coverage CI/CD (51)

### DIFF
--- a/.github/workflows/run-pre-commit.yml
+++ b/.github/workflows/run-pre-commit.yml
@@ -29,6 +29,12 @@ jobs:
       run: |
         python -m pip install interrogate
         interrogate -v --fail-under 40 --exclude "tests/*" --exclude "docs/*" --exclude "setup.py" --exclude "scripts/*" --exclude "examples/*" --exclude "*/__init__.py" --exclude "*/__main__.py" --output docstring-coverage.txt
+
+    - name: Upload docstring coverage
+      uses: actions/upload-artifact@v3
+      with:
+        name: docstring-coverage
+        path: docstring-coverage.txt
         
     - name: pre-commit checks
       run: |

--- a/.github/workflows/run-pre-commit.yml
+++ b/.github/workflows/run-pre-commit.yml
@@ -24,13 +24,15 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install .[dev]
+
+    - name: Run docstring checks with interrogate
+      run: |
+        python -m pip install interrogate
+        interrogate -v --fail-under 40 --exclude "tests/*" --exclude "docs/*" --exclude "setup.py" --exclude "scripts/*" --exclude "examples/*" --exclude "*/__init__.py" --exclude "*/__main__.py" --output docstring-coverage.txt
+        
     - name: pre-commit checks
       run: |
         pre-commit run black --all-files
         # TODO enable once all cyclic imports have been fixed
         # pre-commit run isort --all-files
-    - name: Run docstring checks with interrogate
-      run: |
-        python -m pip install interrogate
-        interrogate -v --fail-under 40 --exclude "tests/*" --exclude "docs/*" --exclude "setup.py" --exclude "scripts/*" --exclude "examples/*" --exclude "*/__init__.py" --exclude "*/__main__.py" --output docstring-coverage.txt
-
+   

--- a/.github/workflows/run-pre-commit.yml
+++ b/.github/workflows/run-pre-commit.yml
@@ -31,7 +31,7 @@ jobs:
         interrogate -v --fail-under 40 --exclude "tests/*" --exclude "docs/*" --exclude "setup.py" --exclude "scripts/*" --exclude "examples/*" --exclude "*/__init__.py" --exclude "*/__main__.py" --output docstring-coverage.txt
 
     - name: Upload docstring coverage
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: docstring-coverage
         path: docstring-coverage.txt

--- a/.github/workflows/run-pre-commit.yml
+++ b/.github/workflows/run-pre-commit.yml
@@ -29,3 +29,8 @@ jobs:
         pre-commit run black --all-files
         # TODO enable once all cyclic imports have been fixed
         # pre-commit run isort --all-files
+    - name: Run docstring checks with interrogate
+      run: |
+        python -m pip install interrogate
+        interrogate -v --fail-under 40 --exclude "tests/*" --exclude "docs/*" --exclude "setup.py" --exclude "scripts/*" --exclude "examples/*" --exclude "*/__init__.py" --exclude "*/__main__.py" --output docstring-coverage.txt
+


### PR DESCRIPTION
I have created a new workflow to install the interrogate package. 
Run the package using a github workflow. 
Output the following:
* Detailed report text file. 
* Badge to display. 

Currently an existing task (black) is failing in the pre-commit workflow. Which I am unsure of its origin, but am sure this failed for previous push requests so may need looking into if this is just me or failing for others. This workflow completes successfully. 

<img width="1299" alt="Screenshot 2025-04-02 at 16 06 01" src="https://github.com/user-attachments/assets/3ea97224-7d37-42ee-b56e-8953764354d0" />

