### PR TITLE
Docstring coverage CI/CD (51)

### DIFF
--- a/.github/workflows/interrogate.yml
+++ b/.github/workflows/interrogate.yml
@@ -1,8 +1,9 @@
 # This workflow will install and run the interrogate package to check for missing docstrings
 
-
 name: Run interrogate
 
+# Interrogate is currently triggered by pushes to the repository which is helpful for testing. 
+# Consider when we want to run interrogate, such as on pull-request.
 on: push
 
 permissions:

--- a/.github/workflows/interrogate.yml
+++ b/.github/workflows/interrogate.yml
@@ -2,9 +2,7 @@
 
 name: Run interrogate
 
-# Interrogate is currently triggered by pushes to the repository which is helpful for testing. 
-# Consider when we want to run interrogate, such as on pull-request.
-on: push
+on: pull_request
 
 permissions:
   contents: read

--- a/.github/workflows/interrogate.yml
+++ b/.github/workflows/interrogate.yml
@@ -24,7 +24,7 @@ jobs:
             - name: interrogate checks
               run: |
                 python -m pip install interrogate
-                interrogate --fail-under 40 --ignore "*/__init__.py" --ignore "*/__main__.py" --output docstring-coverage.txt
+                interrogate --fail-under 40 --exclude "*/__init__.py" --exclude "*/__main__.py" --output docstring-coverage.txt
                 ls -l
             - name: Upload docstring-coverage
               uses: actions/upload-artifact@v4

--- a/.github/workflows/interrogate.yml
+++ b/.github/workflows/interrogate.yml
@@ -24,11 +24,17 @@ jobs:
             - name: interrogate checks
               run: |
                 python -m pip install interrogate
-                interrogate --fail-under 40 --exclude "*/__init__.py" --exclude "*/__main__.py" --output docstring-coverage.txt
+                interrogate -v --fail-under 40 --exclude "*/__init__.py" --exclude "*/__main__.py" --output docstring-coverage.txt --generate-badge badge.svg
                 ls -l
             - name: Upload docstring-coverage
               uses: actions/upload-artifact@v4
               with:
                 name: docstring-coverage
                 path: docstring-coverage.txt
+                if-no-files-found: warn
+            - name: Upload interrogate badge
+              uses: actions/upload-artifact@v4
+              with: 
+                name: interrogate-badge
+                path: interrogate-badge.svg
                 if-no-files-found: warn

--- a/.github/workflows/interrogate.yml
+++ b/.github/workflows/interrogate.yml
@@ -24,7 +24,7 @@ jobs:
             - name: interrogate checks
               run: |
                 python -m pip install interrogate
-                interrogate -v --fail-under 40 --exclude "*/__init__.py" --exclude "*/__main__.py" --output docstring-coverage.txt --generate-badge badge.svg
+                interrogate -v --fail-under 40 --exclude "*/__init__.py" --exclude "*/__main__.py" --output docstring-coverage.txt --generate-badge interrogate-badge.svg
                 ls -l
             - name: Upload docstring-coverage
               uses: actions/upload-artifact@v4

--- a/.github/workflows/interrogate.yml
+++ b/.github/workflows/interrogate.yml
@@ -1,0 +1,34 @@
+# This workflow will install and run the interrogate package to check for missing docstrings
+
+
+name: Run interrogate
+
+on: push
+
+permissions:
+  contents: read
+
+jobs:
+    interrogate:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - name: Set up Python
+              uses: actions/setup-python@v5
+              with:
+                  python-version: '3.x'
+            - name: Install dev dependencies
+              run: |
+                python -m pip install --upgrade pip
+                pip install .[dev]
+            - name: interrogate checks
+              run: |
+                python -m install interrogate
+                interrogate --fail-under 40 --ignore "*/__init__.py" --ignore "*/__main__.py" --output docstring-coverage.txt
+                ls -l
+            - name: Upload docstring-coverage
+              uses: actions/upload-artifact@v4
+              with:
+                name: docstring-coverage
+                path: docstring-coverage.txt
+                if-no-files-found: warn

--- a/.github/workflows/interrogate.yml
+++ b/.github/workflows/interrogate.yml
@@ -23,7 +23,7 @@ jobs:
                 pip install .[dev]
             - name: interrogate checks
               run: |
-                python -m install interrogate
+                python -m pip install interrogate
                 interrogate --fail-under 40 --ignore "*/__init__.py" --ignore "*/__main__.py" --output docstring-coverage.txt
                 ls -l
             - name: Upload docstring-coverage


### PR DESCRIPTION
Added a github workflow which will:
* Intall the interrogate package
* Run the interrogate package with a pass rate of 40 currently (so it passes)
* Output:
    * Detailed report text file.
    * Badge svg file. 

There is an issue with the pre-commit workflow where it fails on the 'black' package. For this reason I moved this into its own workflow. However the interrogate workflow completes successfully. 

<img width="1299" alt="Screenshot 2025-04-02 at 16 06 01" src="https://github.com/user-attachments/assets/1d69e886-5e77-4b3f-a55e-34461b88608b" />
