### PR TITLE
Fix GitHub pip install

### DIFF
--- a/packages/training/src/pyearthtools/training/wrapper/onnx.py
+++ b/packages/training/src/pyearthtools/training/wrapper/onnx.py
@@ -51,6 +51,7 @@ class ONNXWrapper(ModelWrapper):
                 Preloaded onnx session to use, will be saved under `self.model_name`. Defaults to None.
         """
         import onnxruntime as ort
+
         super().__init__(None, data)
         self.record_initialisation()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,8 +48,8 @@ all = [
   "pyearthtools-utils @ git+https://github.com/ACCESS-Community-Hub/PyEarthTools.git#subdirectory=packages/utils",
   "pyearthtools-data[all] @ git+https://github.com/ACCESS-Community-Hub/PyEarthTools.git#subdirectory=packages/data",
   "pyearthtools-pipeline[all] @ git+https://github.com/ACCESS-Community-Hub/PyEarthTools.git#subdirectory=packages/pipeline",
-  "pyearthtools-training[all] @ git+https://github.com/ACCESS-Community-Hub/PyEarthTools.git#subdirectory=packages/training"
-  "pyearthtools-zoo @ git+https://github.com/ACCESS-Community-Hub/PyEarthTools.git#subdirectory=packages/zoo"
+  "pyearthtools-training[all] @ git+https://github.com/ACCESS-Community-Hub/PyEarthTools.git#subdirectory=packages/training",
+  "pyearthtools-zoo @ git+https://github.com/ACCESS-Community-Hub/PyEarthTools.git#subdirectory=packages/zoo",
   "pyearthtools-bundled-fourcastnext @ git+https://github.com/ACCESS-Community-Hub/PyEarthTools.git#subdirectory=packages/bundled_models/fourcastnext"
 ]
 test = ["pytest", "pytest-cov", "pytest-xdist", "pudb"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,11 +37,20 @@ training = [
   "pyearthtools-pipeline @ git+https://github.com/ACCESS-Community-Hub/PyEarthTools.git#subdirectory=packages/pipeline",
   "pyearthtools-training @ git+https://github.com/ACCESS-Community-Hub/PyEarthTools.git#subdirectory=packages/training"
 ]
+zoo = [
+  "pyearthtools-utils @ git+https://github.com/ACCESS-Community-Hub/PyEarthTools.git#subdirectory=packages/utils",
+  "pyearthtools-data @ git+https://github.com/ACCESS-Community-Hub/PyEarthTools.git#subdirectory=packages/data",
+  "pyearthtools-pipeline @ git+https://github.com/ACCESS-Community-Hub/PyEarthTools.git#subdirectory=packages/pipeline",
+  "pyearthtools-training @ git+https://github.com/ACCESS-Community-Hub/PyEarthTools.git#subdirectory=packages/training",
+  "pyearthtools-zoo @ git+https://github.com/ACCESS-Community-Hub/PyEarthTools.git#subdirectory=packages/zoo"
+]
 all = [
   "pyearthtools-utils @ git+https://github.com/ACCESS-Community-Hub/PyEarthTools.git#subdirectory=packages/utils",
   "pyearthtools-data[all] @ git+https://github.com/ACCESS-Community-Hub/PyEarthTools.git#subdirectory=packages/data",
   "pyearthtools-pipeline[all] @ git+https://github.com/ACCESS-Community-Hub/PyEarthTools.git#subdirectory=packages/pipeline",
   "pyearthtools-training[all] @ git+https://github.com/ACCESS-Community-Hub/PyEarthTools.git#subdirectory=packages/training"
+  "pyearthtools-zoo @ git+https://github.com/ACCESS-Community-Hub/PyEarthTools.git#subdirectory=packages/zoo"
+  "pyearthtools-bundled-fourcastnext @ git+https://github.com/ACCESS-Community-Hub/PyEarthTools.git#subdirectory=packages/bundled_models/fourcastnext"
 ]
 test = ["pytest", "pytest-cov", "pytest-xdist", "pudb"]
 dev = ["pre-commit", "black==25.1.0", "interrogate"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,14 @@ zoo = [
   "pyearthtools-training @ git+https://github.com/ACCESS-Community-Hub/PyEarthTools.git#subdirectory=packages/training",
   "pyearthtools-zoo @ git+https://github.com/ACCESS-Community-Hub/PyEarthTools.git#subdirectory=packages/zoo"
 ]
+bundled-fourcastnext = [
+  "pyearthtools-utils @ git+https://github.com/ACCESS-Community-Hub/PyEarthTools.git#subdirectory=packages/utils",
+  "pyearthtools-data @ git+https://github.com/ACCESS-Community-Hub/PyEarthTools.git#subdirectory=packages/data",
+  "pyearthtools-pipeline @ git+https://github.com/ACCESS-Community-Hub/PyEarthTools.git#subdirectory=packages/pipeline",
+  "pyearthtools-training[lightning] @ git+https://github.com/ACCESS-Community-Hub/PyEarthTools.git#subdirectory=packages/training",
+  "pyearthtools-zoo @ git+https://github.com/ACCESS-Community-Hub/PyEarthTools.git#subdirectory=packages/zoo",
+  "pyearthtools-bundled-fourcastnext @ git+https://github.com/ACCESS-Community-Hub/PyEarthTools.git#subdirectory=packages/bundled_models/fourcastnext"
+]
 all = [
   "pyearthtools-utils @ git+https://github.com/ACCESS-Community-Hub/PyEarthTools.git#subdirectory=packages/utils",
   "pyearthtools-data[all] @ git+https://github.com/ACCESS-Community-Hub/PyEarthTools.git#subdirectory=packages/data",


### PR DESCRIPTION
This PR add zoo and bundled-fourcastnext to the pyproject.toml file so they can be installed directly (i.e. without git clone) using `pip install` (e.g. `pip install "pyearthtools[zoo] @ git+https://github.com/jennan/PyEarthTools.git@fix_github_pip_install"`), either on their own or as part of the "all" bundle.