### PR TITLE
Check wb2 license

### DIFF
--- a/packages/data/src/pyearthtools/data/download/weatherbench.py
+++ b/packages/data/src/pyearthtools/data/download/weatherbench.py
@@ -4,6 +4,7 @@ import textwrap
 import hashlib
 from pathlib import Path
 from typing import Literal
+from abc import ABC, abstractmethod
 
 import fsspec
 import xarray as xr
@@ -159,7 +160,7 @@ def open_local_dataset(path: Path, variables: list[str], level: list[int]) -> xr
     return dset_full
 
 
-class WeatherBench2(AdvancedTimeDataIndex):
+class WeatherBench2(ABC, AdvancedTimeDataIndex):
     """WeatherBench2 cloud-optimized ground truth and baseline datasets
 
     https://github.com/google-research/weatherbench2
@@ -254,11 +255,9 @@ class WeatherBench2(AdvancedTimeDataIndex):
                 ds = Select(level=level, ignore_missing=True)(ds)
             return ds
 
-        licence_remote = url.rsplit("/", maxsplit=1)[0] + "/LICENSE"
-
         if download_dir is None:
             ds = open_online_dataset()
-            license = licence_remote
+            license = self.license_url
 
         else:
             # use a hash of the url to identify the dataset subfolder
@@ -276,7 +275,7 @@ class WeatherBench2(AdvancedTimeDataIndex):
                 ds = open_local_dataset(download_path, variables, level)
 
             if not (license := download_path / "LICENSE").is_file():
-                with fsspec.open(licence_remote, "rt").open() as fd:
+                with fsspec.open(self.license_url, "rt").open() as fd:
                     license_txt = fd.read()
                     license.write_text(license_txt)
 
@@ -291,6 +290,11 @@ class WeatherBench2(AdvancedTimeDataIndex):
         self._ds = ds
         self._license = license
         self._kwargs = kwargs
+
+    @property
+    @abstractmethod
+    def license_url(self):
+        pass
 
     @property
     def _desc_(self) -> dict[str, str]:
@@ -358,6 +362,10 @@ class WB2ERA5(WeatherBench2):
         super().__init__(url, **kwargs)
         self.resolution = resolution
 
+    @property
+    def license_url(self):
+        return "gs://weatherbench2/datasets/era5/LICENSE"
+
     @classmethod
     def sample(cls):
         """Example subset of the dataset"""
@@ -414,6 +422,10 @@ class WB2ERA5Clim(WeatherBench2):
         super().__init__(url, **kwargs)
         self.period = period
         self.resolution = resolution
+
+    @property
+    def license_url(self):
+        return "gs://weatherbench2/datasets/era5-hourly-climatology/LICENSE"
 
     @classmethod
     def sample(cls):

--- a/packages/data/src/pyearthtools/data/download/weatherbench.py
+++ b/packages/data/src/pyearthtools/data/download/weatherbench.py
@@ -172,11 +172,6 @@ class WeatherBench2(AdvancedTimeDataIndex):
     https://doi.org/10.1029/2023MS004019
     """
 
-    _desc_ = {
-        "singleline": "WeatherBench2 cloud-optimized ground truth and baseline datasets",
-        "link": "https://github.com/google-research/weatherbench2",
-    }
-
     @decorators.alias_arguments(variables=["variable"], level=["levels", "level_value"])
     @decorators.variable_modifications("variables")
     def __init__(
@@ -276,6 +271,13 @@ class WeatherBench2(AdvancedTimeDataIndex):
         self._kwargs = kwargs
 
     @property
+    def _desc_(self) -> dict[str, str]:
+        return {
+            "singleline": self.__doc__.splitlines()[0],
+            "link": "https://github.com/google-research/weatherbench2",
+        }
+
+    @property
     def dataset(self) -> xr.Dataset:
         """Get full dataset for this obj"""
         return self._ds
@@ -304,11 +306,6 @@ class WB2ERA5(WeatherBench2):
     Journal of Advances in Modeling Earth Systems, 16, e2023MS004019
     https://doi.org/10.1029/2023MS004019
     """
-
-    _desc_ = {
-        "singleline": "WeatherBench2 cloud-optimized ground truth ERA5 dataset",
-        "link": "https://github.com/google-research/weatherbench2",
-    }
 
     DATASETS = {
         "raw": "1959-2023_01_10-full_37-1h-0p25deg-chunk-1.zarr",

--- a/packages/data/src/pyearthtools/data/download/weatherbench.py
+++ b/packages/data/src/pyearthtools/data/download/weatherbench.py
@@ -1,9 +1,11 @@
+import sys
 import logging
 import textwrap
 import hashlib
 from pathlib import Path
 from typing import Literal
 
+import fsspec
 import xarray as xr
 from numcodecs.blosc import Blosc
 from tqdm.dask import TqdmCallback
@@ -183,6 +185,7 @@ class WeatherBench2(AdvancedTimeDataIndex):
         transforms: Transform | TransformCollection | None = None,
         chunks: int | dict | Literal["auto"] | None = "auto",
         download_dir: str | Path | None = None,
+        license_ok: bool = False,
         **kwargs,
     ):
         """
@@ -208,6 +211,8 @@ class WeatherBench2(AdvancedTimeDataIndex):
                 Chunking used to load data into Dask arrays. Defaults to "auto".
             download_dir (str | Path, optional):
                 Folder where to save a copy of the dataset. Defaults to None.
+            license_ok (bool, optional):
+                License has been read. Defaults to False.
         """
         super().__init__(transforms or TransformCollection(), data_interval="1 hour")
         self.record_initialisation()
@@ -249,8 +254,15 @@ class WeatherBench2(AdvancedTimeDataIndex):
                 ds = Select(level=level, ignore_missing=True)(ds)
             return ds
 
+        def read_online_license():
+            licence_url = url.rsplit("/", maxsplit=1)[0] + "/LICENSE"
+            with fsspec.open(licence_url, "rt").open() as fd:
+                license = fd.read()
+            return license
+
         if download_dir is None:
             ds = open_online_dataset()
+            license = read_online_license()
 
         else:
             # use a hash of the url to identify the dataset subfolder
@@ -267,7 +279,22 @@ class WeatherBench2(AdvancedTimeDataIndex):
                 (download_path / "dataset_url").write_text(url)
                 ds = open_local_dataset(download_path, variables, level)
 
+            if (license_path := download_path / "license").isfile():
+                license = license_path.read_text(license)
+            else:
+                license = read_online_license()
+                license_path.write_text(license)
+
+        if not license_ok:
+            print(
+                f"Make sure to check the LICENSE for this {self.__class__.__name__} dataset. "
+                "Some WeatherBench2 datasets allow commercial use. Others only permit research use. "
+                "The license text can be accessed via the `.license` property.",
+                file=sys.stderr,
+            )
+
         self._ds = ds
+        self._license = license
         self._kwargs = kwargs
 
     @property
@@ -281,6 +308,11 @@ class WeatherBench2(AdvancedTimeDataIndex):
     def dataset(self) -> xr.Dataset:
         """Get full dataset for this obj"""
         return self._ds
+
+    @property
+    def license(self) -> str:
+        """Get the license for this dataset"""
+        return self._license
 
     def get(self, time: str):
         """Get timestep from dataset"""

--- a/packages/data/src/pyearthtools/data/download/weatherbench.py
+++ b/packages/data/src/pyearthtools/data/download/weatherbench.py
@@ -254,15 +254,11 @@ class WeatherBench2(AdvancedTimeDataIndex):
                 ds = Select(level=level, ignore_missing=True)(ds)
             return ds
 
-        def read_online_license():
-            licence_url = url.rsplit("/", maxsplit=1)[0] + "/LICENSE"
-            with fsspec.open(licence_url, "rt").open() as fd:
-                license = fd.read()
-            return license
+        licence_remote = url.rsplit("/", maxsplit=1)[0] + "/LICENSE"
 
         if download_dir is None:
             ds = open_online_dataset()
-            license = read_online_license()
+            license = licence_remote
 
         else:
             # use a hash of the url to identify the dataset subfolder
@@ -279,17 +275,16 @@ class WeatherBench2(AdvancedTimeDataIndex):
                 (download_path / "dataset_url").write_text(url)
                 ds = open_local_dataset(download_path, variables, level)
 
-            if (license_path := download_path / "license").isfile():
-                license = license_path.read_text(license)
-            else:
-                license = read_online_license()
-                license_path.write_text(license)
+            if not (license := download_path / "LICENSE").is_file():
+                with fsspec.open(licence_remote, "rt").open() as fd:
+                    license_txt = fd.read()
+                    license.write_text(license_txt)
 
         if not license_ok:
             print(
                 f"Make sure to check the LICENSE for this {self.__class__.__name__} dataset. "
                 "Some WeatherBench2 datasets allow commercial use. Others only permit research use. "
-                "The license text can be accessed via the `.license` property.",
+                "The license text can be accessed via the `.license()` method.",
                 file=sys.stderr,
             )
 
@@ -309,10 +304,11 @@ class WeatherBench2(AdvancedTimeDataIndex):
         """Get full dataset for this obj"""
         return self._ds
 
-    @property
     def license(self) -> str:
         """Get the license for this dataset"""
-        return self._license
+        with fsspec.open(self._license, "rt").open() as fd:
+            license_txt = fd.read()
+        return license_txt
 
     def get(self, time: str):
         """Get timestep from dataset"""

--- a/packages/nci_site_archive/src/site_archive_nci/_AusTopo.py
+++ b/packages/nci_site_archive/src/site_archive_nci/_AusTopo.py
@@ -33,6 +33,7 @@ from site_archive_nci.utilities import check_project
 
 import xarray as xr
 
+
 @register_archive("AusTopo")
 class AusTopo(Index):
     """
@@ -41,7 +42,7 @@ class AusTopo(Index):
     https://dx.doi.org/10.25914/60a10aa56dd1b
 
     Data is covered by Attribution-ShareAlike 4.0 International
-    
+
     """
 
     @property
@@ -64,27 +65,25 @@ class AusTopo(Index):
         """
         check_project(project_code="gh70")
 
-        base_transform = (transforms or TransformCollection())
+        base_transform = transforms or TransformCollection()
         super().__init__(transforms=base_transform)
         self.record_initialisation()
 
     def get(self, date_of_interest, **kwargs):
-        '''
+        """
         Load the topography, but replace the date on the file with the
         date that is being requested, so that even though the underlying data
-        is static, it can be requests against any date/time. 
-        '''
+        is static, it can be requests against any date/time.
+        """
 
         file = self.load_file()
         doi = Petdt(date_of_interest)
         xr_time = doi.datetime64()
-        file['time'] = [xr_time] 
-        file = file.rename({'lat': 'latitude', 'lon': 'longitude'})
+        file["time"] = [xr_time]
+        file = file.rename({"lat": "latitude", "lon": "longitude"})
 
         return file
 
     def load_file(self):
-        file = xr.open_dataset('/g/data/gh70/ANUClimate/v2-0/topogrid/dem01/ANUClimate_v2-0_dem01.nc')
+        file = xr.open_dataset("/g/data/gh70/ANUClimate/v2-0/topogrid/dem01/ANUClimate_v2-0_dem01.nc")
         return file
-
-    

--- a/packages/nci_site_archive/src/site_archive_nci/_AusTopo.py
+++ b/packages/nci_site_archive/src/site_archive_nci/_AusTopo.py
@@ -18,14 +18,9 @@ Himawari 8/9 satellite data
 
 from __future__ import annotations
 
-import datetime
-from glob import glob
-from pathlib import Path
 
-import pyearthtools.data
-from pyearthtools.data import Petdt, TimeDelta
-from pyearthtools.data.exceptions import DataNotFoundError
-from pyearthtools.data.indexes import ArchiveIndex, decorators, StaticDataIndex, Index
+from pyearthtools.data import Petdt
+from pyearthtools.data.indexes import Index
 from pyearthtools.data.transforms import Transform, TransformCollection
 from pyearthtools.data.archive import register_archive
 


### PR DESCRIPTION
This PR adds a message to inform users to review the license of WeatherBench2 datasets:

- The message is printed on stderr (instead of using `logging`) to avoid users silencing the message by mistake (e.g. missing logging handler) or explicitly (by silencing all warnings for example). Users can silence it by setting `license_ok=True` to the constructor.
- License is saved locally if `download_dir` parameter is set, as part of the download.
- License is only retrieved when calling `.license()` method, to avoid making the constructor too slow, as I noted it could take up to 30s to retrieve this file.