### PR TITLE
Remove BackwardsCompatibility uses

### DIFF
--- a/packages/data/src/pyearthtools/data/modifications/modification.py
+++ b/packages/data/src/pyearthtools/data/modifications/modification.py
@@ -149,4 +149,4 @@ class Modification(metaclass=ABCMeta):
         if isinstance(data, xr.Dataset):
             data = data[variable]
 
-        return pyearthtools.data.transforms.attributes.update(self.attribute_update)(data)
+        return pyearthtools.data.transforms.attributes.SetAttributes(self.attribute_update)(data)

--- a/packages/data/src/pyearthtools/data/transforms/__init__.py
+++ b/packages/data/src/pyearthtools/data/transforms/__init__.py
@@ -71,7 +71,7 @@ from pyearthtools.data.transforms import (
 from pyearthtools.data.transforms.default import get_default_transforms
 
 # from pyearthtools.data.transforms.mask import MaskTransform as mask
-from pyearthtools.data.transforms.derive import derive, Derive
+from pyearthtools.data.transforms.derive import Derive
 
 from pyearthtools.data.transforms import projection
 
@@ -92,7 +92,6 @@ __all__ = [
     "region",
     "mask",
     "get_default_transform",
-    "derive",
     "Derive",
     "projection",
     "get_default_transforms",

--- a/packages/data/src/pyearthtools/data/transforms/attributes.py
+++ b/packages/data/src/pyearthtools/data/transforms/attributes.py
@@ -269,4 +269,3 @@ class Rename(Transform):
 
     def apply(self, dataset: xr.Dataset) -> xr.Dataset:
         return dataset.rename(**{key: self._names[key] for key in self._names if key in dataset})
-

--- a/packages/data/src/pyearthtools/data/transforms/attributes.py
+++ b/packages/data/src/pyearthtools/data/transforms/attributes.py
@@ -107,9 +107,6 @@ class SetAttributes(Transform):
         return data_obj
 
 
-update = SetAttributes
-
-
 def _get_encoding_from_ds(reference: xr.DataArray | xr.Dataset, limit: list[str] | None = None):
     encoding: dict[str, dict[str, Any]] = {}
     relevant_encoding = limit or [

--- a/packages/data/src/pyearthtools/data/transforms/attributes.py
+++ b/packages/data/src/pyearthtools/data/transforms/attributes.py
@@ -200,10 +200,6 @@ class SetEncoding(Transform):
         return dataset
 
 
-@BackwardsCompatibility(SetEncoding)
-def set_encoding(*args, **kwargs) -> Transform: ...
-
-
 class SetType(Transform):
     """Set type of variables"""
 

--- a/packages/data/src/pyearthtools/data/transforms/attributes.py
+++ b/packages/data/src/pyearthtools/data/transforms/attributes.py
@@ -23,7 +23,6 @@ from typing import Any, Literal
 import xarray as xr
 
 from pyearthtools.data.transforms import Transform
-from pyearthtools.utils.decorators import BackwardsCompatibility
 
 
 def _get_attributes_from_ds(reference: xr.DataArray | xr.Dataset) -> dict[str, dict[str, Any]]:
@@ -274,6 +273,3 @@ class Rename(Transform):
     def apply(self, dataset: xr.Dataset) -> xr.Dataset:
         return dataset.rename(**{key: self._names[key] for key in self._names if key in dataset})
 
-
-@BackwardsCompatibility(Rename)
-def rename(*args, **kwargs) -> Transform: ...

--- a/packages/data/src/pyearthtools/data/transforms/attributes.py
+++ b/packages/data/src/pyearthtools/data/transforms/attributes.py
@@ -108,11 +108,7 @@ class SetAttributes(Transform):
         return data_obj
 
 
-@BackwardsCompatibility(SetAttributes)
-def set_attributes(*args, **kwargs) -> Transform: ...
-
-
-update = set_attributes
+update = SetAttributes
 
 
 def _get_encoding_from_ds(reference: xr.DataArray | xr.Dataset, limit: list[str] | None = None):

--- a/packages/data/src/pyearthtools/data/transforms/attributes.py
+++ b/packages/data/src/pyearthtools/data/transforms/attributes.py
@@ -244,10 +244,6 @@ class SetType(Transform):
         return dataset
 
 
-@BackwardsCompatibility(SetType)
-def set_type(*args, **kwargs) -> Transform: ...
-
-
 class Rename(Transform):
     """Rename Components inside Dataset"""
 

--- a/packages/data/src/pyearthtools/data/transforms/coordinates.py
+++ b/packages/data/src/pyearthtools/data/transforms/coordinates.py
@@ -29,8 +29,6 @@ from pyearthtools.data.transforms.attributes import SetType
 from pyearthtools.data.warnings import pyearthtoolsDataWarning
 from pyearthtools.data.exceptions import DataNotFoundError
 
-from pyearthtools.utils.decorators import BackwardsCompatibility
-
 DASK_IMPORTED = False
 try:
     import dask
@@ -679,6 +677,3 @@ class Pad(Transform):
     # def _info_(self) -> Any | dict:
     #     return dict(coordinates=self._coordinates, **self._kwargs)
 
-
-@BackwardsCompatibility(Pad)
-def pad(*args, **kwargs) -> Transform: ...

--- a/packages/data/src/pyearthtools/data/transforms/coordinates.py
+++ b/packages/data/src/pyearthtools/data/transforms/coordinates.py
@@ -560,10 +560,6 @@ class Expand(Transform):
         return dataset
 
 
-@BackwardsCompatibility(Expand)
-def expand(*args, **kwargs) -> Transform: ...
-
-
 def SelectFlatten(
     coordinates: dict[str, tuple[Any] | Any] | None = None,
     tolerance: float = 0.01,

--- a/packages/data/src/pyearthtools/data/transforms/coordinates.py
+++ b/packages/data/src/pyearthtools/data/transforms/coordinates.py
@@ -676,4 +676,3 @@ class Pad(Transform):
     # @property
     # def _info_(self) -> Any | dict:
     #     return dict(coordinates=self._coordinates, **self._kwargs)
-

--- a/packages/data/src/pyearthtools/data/transforms/default.py
+++ b/packages/data/src/pyearthtools/data/transforms/default.py
@@ -44,6 +44,6 @@ def get_default_transforms(
         transforms.append(pyearthtools.data.transforms.coordinates.StandardCoordinateNames(**REPLACEMENT_NAMES))  # type: ignore
         # transforms.append(pyearthtools.data.transforms.coordinates.StandardLongitude())
     # if intelligence_level > 1:
-    #     transforms.append(pyearthtools.data.transforms.coordinates.set_type("float"))
+    #     transforms.append(pyearthtools.data.transforms.coordinates.SetType("float"))
 
     return transforms

--- a/packages/data/src/pyearthtools/data/transforms/derive.py
+++ b/packages/data/src/pyearthtools/data/transforms/derive.py
@@ -29,7 +29,6 @@ import logging
 
 
 from pyearthtools.data.transforms import Transform
-from pyearthtools.utils.decorators import BackwardsCompatibility
 
 LOG = logging.getLogger("pyearthtools.data")
 
@@ -507,10 +506,6 @@ class Derive(Transform):
 
     def apply(self, dataset: xr.Dataset) -> xr.Dataset:
         return derive_equations(dataset, drop=self._drop, equation=self._equation)
-
-
-@BackwardsCompatibility(Derive)
-def derive(*args, **kwargs) -> Transform: ...
 
 
 # def equations(equation: str):

--- a/packages/data/src/pyearthtools/data/transforms/dimensions.py
+++ b/packages/data/src/pyearthtools/data/transforms/dimensions.py
@@ -133,4 +133,3 @@ class Expand(Transform):
 
         data = dataset.expand_dims(_dim, axis=self._axis, **self._kwargs)
         return data
-

--- a/packages/data/src/pyearthtools/data/transforms/dimensions.py
+++ b/packages/data/src/pyearthtools/data/transforms/dimensions.py
@@ -19,7 +19,6 @@ from typing import Optional, Literal, TypeVar
 import xarray as xr
 
 from pyearthtools.data.transforms.transform import Transform
-from pyearthtools.utils.decorators import BackwardsCompatibility
 
 XR = TypeVar("XR", xr.Dataset, xr.DataArray)
 
@@ -58,10 +57,6 @@ class StandardDimensionNames(Transform):
                 if falsename in dataset:
                     dataset = dataset.drop(falsename)
         return dataset
-
-
-@BackwardsCompatibility(StandardDimensionNames)
-def force_standard_dimension_names(*args, **kwargs: str) -> Transform: ...
 
 
 class Expand(Transform):
@@ -139,6 +134,3 @@ class Expand(Transform):
         data = dataset.expand_dims(_dim, axis=self._axis, **self._kwargs)
         return data
 
-
-@BackwardsCompatibility(Expand)
-def expand(*args, **kwargs) -> Transform: ...

--- a/packages/data/src/pyearthtools/data/transforms/interpolation.py
+++ b/packages/data/src/pyearthtools/data/transforms/interpolation.py
@@ -25,8 +25,6 @@ import pyearthtools.data
 from pyearthtools.data.transforms.transform import Transform
 from pyearthtools.data.transforms.utils import parse_dataset
 
-from pyearthtools.utils.decorators import BackwardsCompatibility
-
 xESMF_IMPORTED = True
 try:
     import xesmf as xe  # type: ignore
@@ -261,10 +259,6 @@ class InterpolateNan(Transform):
         return tf_revert_reindex(
             encode(tf_reindex(dataset).interpolate_na(dim=self._dim, method=self._method, **self._kwargs))
         )  # type: ignore
-
-
-@BackwardsCompatibility(InterpolateNan)
-def interpolate_na(*args, **kwargs): ...
 
 
 ### Model levels to pressure level transform needed

--- a/packages/data/src/pyearthtools/data/transforms/mask.py
+++ b/packages/data/src/pyearthtools/data/transforms/mask.py
@@ -26,8 +26,6 @@ import xarray as xr
 from pyearthtools.data.transforms.transform import Transform
 from pyearthtools.data.transforms.utils import parse_dataset
 
-from pyearthtools.utils.decorators import BackwardsCompatibility
-
 OPERATIONS = ["==", "!=", ">", "<", ">=", "<="]
 OPERATIONS_TYPE = Literal["==", "!=", ">", "<", ">=", "<="]
 
@@ -305,10 +303,6 @@ class Dataset(UnderlyingMaskTransform):
         )
 
 
-@BackwardsCompatibility(Dataset)
-def dataset(*a, **k): ...
-
-
 class Replace(UnderlyingMaskTransform):
     def __init__(
         self,
@@ -349,10 +343,6 @@ class Replace(UnderlyingMaskTransform):
             replacement_value=self._replacement_value,
             operation=self._operation,  # type: ignore
         )
-
-
-@BackwardsCompatibility(Replace)
-def replace_value(*a, **k): ...
 
 
 __all__ = ["Dataset", "Replace"]

--- a/packages/data/src/pyearthtools/data/transforms/optimisation.py
+++ b/packages/data/src/pyearthtools/data/transforms/optimisation.py
@@ -46,4 +46,3 @@ class Rechunk(Transform):
                     raise ValueError(f"Could not find 'chunksizes' in encoding of {var}")
             dataset[var].data = dataset[var].data.rechunk(chunks)
         return dataset
-

--- a/packages/data/src/pyearthtools/data/transforms/optimisation.py
+++ b/packages/data/src/pyearthtools/data/transforms/optimisation.py
@@ -20,8 +20,6 @@ from typing import Literal, Any
 import xarray as xr
 from pyearthtools.data.transforms.transform import Transform
 
-from pyearthtools.utils.decorators import BackwardsCompatibility
-
 
 class Rechunk(Transform):
     """Rechunk data"""
@@ -49,6 +47,3 @@ class Rechunk(Transform):
             dataset[var].data = dataset[var].data.rechunk(chunks)
         return dataset
 
-
-@BackwardsCompatibility(Rechunk)
-def rechunk(*args, **kwargs): ...

--- a/packages/data/src/pyearthtools/data/transforms/region.py
+++ b/packages/data/src/pyearthtools/data/transforms/region.py
@@ -306,4 +306,3 @@ def Geosearch(
         shapefile = geo.geometry
 
     return ShapeFile(shapefile, crs=crs)
-

--- a/packages/data/src/pyearthtools/data/transforms/region.py
+++ b/packages/data/src/pyearthtools/data/transforms/region.py
@@ -33,8 +33,6 @@ except ImportError:
 from pyearthtools.data.transforms import Transform
 from pyearthtools.data.transforms.utils import parse_dataset
 
-from pyearthtools.utils.decorators import BackwardsCompatibility
-
 
 RegionLookupFILE = Path(__file__).parent / "RegionLookup.yaml"
 
@@ -137,10 +135,6 @@ class Select(Transform):
         return subset_dataset
 
 
-@BackwardsCompatibility(Select)
-def sel(*args, **kwargs): ...
-
-
 class ISelect(Transform):
     """ISelect"""
 
@@ -158,10 +152,6 @@ class ISelect(Transform):
         # TODO Add automatic coordinate analysis, slice on 0-360 with a ds with -180-180
         subset_dataset = dataset.isel(**self._sel_kwargs)
         return subset_dataset
-
-
-@BackwardsCompatibility(ISelect)
-def isel(*args, **kwargs): ...
 
 
 def PointBox(point: tuple[float], size: float) -> Transform:
@@ -185,10 +175,6 @@ def PointBox(point: tuple[float], size: float) -> Transform:
         tuple(map(lambda x: x + size, point)),
     )
     return Bounding(edges[0][0], edges[1][0], edges[0][1], edges[1][1])
-
-
-@BackwardsCompatibility(PointBox)
-def point_box(*args, **kwargs): ...
 
 
 def Lookup(key: str, regionfile: str | Path = RegionLookupFILE) -> Transform:
@@ -220,10 +206,6 @@ def Lookup(key: str, regionfile: str | Path = RegionLookupFILE) -> Transform:
         return Bounding(**bounding_box)
 
     return Bounding(*bounding_box)
-
-
-@BackwardsCompatibility(Lookup)
-def lookup(*args, **kwargs): ...
 
 
 class ShapeFile(Transform):
@@ -283,10 +265,6 @@ class ShapeFile(Transform):
         self._shapefile.plot(**kwargs)
 
 
-@BackwardsCompatibility(ShapeFile)
-def from_shapefile(*args, **kwargs): ...
-
-
 def Geosearch(
     key: str,
     column: str | None = None,
@@ -329,6 +307,3 @@ def Geosearch(
 
     return ShapeFile(shapefile, crs=crs)
 
-
-@BackwardsCompatibility(Geosearch)
-def from_geosearch(*args, **kwargs): ...

--- a/packages/data/src/pyearthtools/data/transforms/values.py
+++ b/packages/data/src/pyearthtools/data/transforms/values.py
@@ -25,7 +25,6 @@ import numpy as np
 
 import pyearthtools.data
 from pyearthtools.data.transforms.transform import Transform
-from pyearthtools.utils.decorators import BackwardsCompatibility
 
 
 class Fill(Transform):
@@ -135,10 +134,6 @@ class AddFlaggedObs(Transform):
                 dataset[var_name] = dataset[var_name].where(~mask, np.nan)
 
         return dataset
-
-
-@BackwardsCompatibility(Fill)
-def fill(*args, **kwargs): ...
 
 
 def ffill(*a, **b):

--- a/packages/data/src/pyearthtools/data/transforms/variables.py
+++ b/packages/data/src/pyearthtools/data/transforms/variables.py
@@ -132,4 +132,3 @@ class Select(Transform):
             return dataset
 
         return dataset[list(var_included)]
-

--- a/packages/data/src/pyearthtools/data/transforms/variables.py
+++ b/packages/data/src/pyearthtools/data/transforms/variables.py
@@ -20,8 +20,6 @@ import xarray as xr
 import pyearthtools.data.transforms.attributes as attr
 from pyearthtools.data.transforms.transform import Transform
 
-from pyearthtools.utils.decorators import BackwardsCompatibility
-
 # Backwards compatability
 rename_variables = attr.Rename
 replace_name_deviation = rename_variables
@@ -56,14 +54,6 @@ class Trim(Transform):
         if not var_included:
             return dataset
         return dataset[var_included]
-
-
-@BackwardsCompatibility(Trim)
-def trim(*args) -> Transform: ...
-
-
-@BackwardsCompatibility(Trim)
-def variable_trim(*args) -> Transform: ...
 
 
 class Drop(Transform):
@@ -143,6 +133,3 @@ class Select(Transform):
 
         return dataset[list(var_included)]
 
-
-@BackwardsCompatibility(Drop)
-def drop(*args) -> Transform: ...

--- a/packages/data/src/pyearthtools/data/transforms/variables.py
+++ b/packages/data/src/pyearthtools/data/transforms/variables.py
@@ -23,7 +23,7 @@ from pyearthtools.data.transforms.transform import Transform
 from pyearthtools.utils.decorators import BackwardsCompatibility
 
 # Backwards compatability
-rename_variables = attr.rename
+rename_variables = attr.Rename
 replace_name_deviation = rename_variables
 
 

--- a/packages/pipeline/src/pyearthtools/pipeline/operations/dask/normalisation.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/dask/normalisation.py
@@ -26,7 +26,6 @@ import dask.array as da
 
 from pyearthtools.data.utils import parse_path
 
-from pyearthtools.utils.decorators import BackwardsCompatibility
 from pyearthtools.pipeline.operations.dask.dask import DaskOperation
 
 
@@ -135,10 +134,6 @@ class Division(daskNormalisation):
 
     def denormalise(self, sample):
         return sample * self.expand(self.division_factor, sample)
-
-
-@BackwardsCompatibility(Division)
-def TemporalDifference(*a, **k): ...
 
 
 class Evaluated(daskNormalisation):

--- a/packages/pipeline/src/pyearthtools/pipeline/operations/numpy/normalisation.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/numpy/normalisation.py
@@ -21,7 +21,6 @@ import numpy as np
 
 from pyearthtools.data.utils import parse_path
 
-from pyearthtools.utils.decorators import BackwardsCompatibility
 from pyearthtools.pipeline.operation import Operation
 
 
@@ -128,10 +127,6 @@ class Division(numpyNormalisation):
 
     def denormalise(self, sample):
         return sample * self.expand(self.division_factor, sample)
-
-
-@BackwardsCompatibility(Division)
-def TemporalDifference(*a, **k): ...
 
 
 class Evaluated(numpyNormalisation):

--- a/packages/pipeline/src/pyearthtools/pipeline/operations/transform/add_coordinates.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/transform/add_coordinates.py
@@ -53,7 +53,7 @@ class AddCoordinates(Transform):
 
     def apply(self, data: xr.Dataset):
         dims = list(data.dims)
-        rebuild_encoding = pyearthtools.data.transforms.attributes.set_encoding(
+        rebuild_encoding = pyearthtools.data.transforms.attributes.SetEncoding(
             reference=data
         ) + pyearthtools.data.transforms.attributes.SetAttributes(reference=data)
 

--- a/packages/pipeline/src/pyearthtools/pipeline/operations/transform/add_coordinates.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/transform/add_coordinates.py
@@ -55,7 +55,7 @@ class AddCoordinates(Transform):
         dims = list(data.dims)
         rebuild_encoding = pyearthtools.data.transforms.attributes.set_encoding(
             reference=data
-        ) + pyearthtools.data.transforms.attributes.set_attributes(reference=data)
+        ) + pyearthtools.data.transforms.attributes.SetAttributes(reference=data)
 
         for coord in self.coordinates:
             if coord in data:

--- a/packages/pipeline/src/pyearthtools/pipeline/operations/xarray/metadata.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/xarray/metadata.py
@@ -178,7 +178,7 @@ class Attributes(Operation):
             recognised_types=(xr.Dataset, xr.DataArray),
         )
         self.record_initialisation()
-        self._attributes = pyearthtools.data.transforms.attributes.set_attributes(attrs=attributes, apply_on=apply_on)
+        self._attributes = pyearthtools.data.transforms.attributes.SetAttributes(attrs=attributes, apply_on=apply_on)
 
     def apply_func(self, sample: T) -> T:
         return self._attributes(sample)
@@ -214,12 +214,12 @@ class MaintainAttributes(Operation):
         self._attributes = (
             None
             if reference is None
-            else pyearthtools.data.transforms.attributes.set_attributes(reference=xr.open_dataset(reference))
+            else pyearthtools.data.transforms.attributes.SetAttributes(reference=xr.open_dataset(reference))
         )
 
     def apply_func(self, sample: T) -> T:
         if not self._attributes:
-            self._attributes = pyearthtools.data.transforms.attributes.set_attributes(reference=sample)
+            self._attributes = pyearthtools.data.transforms.attributes.SetAttributes(reference=sample)
         return sample
 
     def undo_func(self, sample: T) -> T:

--- a/packages/pipeline/src/pyearthtools/pipeline/operations/xarray/metadata.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/xarray/metadata.py
@@ -88,7 +88,7 @@ class Encoding(Operation):
             recognised_types=(xr.Dataset, xr.DataArray),
         )
         self.record_initialisation()
-        self._encoding = pyearthtools.data.transforms.attributes.set_encoding(encoding)
+        self._encoding = pyearthtools.data.transforms.attributes.SetEncoding(encoding)
 
     def apply_func(self, sample: T) -> T:
         return self._encoding(sample)
@@ -124,13 +124,13 @@ class MaintainEncoding(Operation):
         self._encoding = (
             None
             if reference is None
-            else pyearthtools.data.transforms.attributes.set_encoding(reference=xr.open_dataset(reference), limit=limit)
+            else pyearthtools.data.transforms.attributes.SetEncoding(reference=xr.open_dataset(reference), limit=limit)
         )
         self._limit = limit
 
     def apply_func(self, sample: T) -> T:
         if not self._encoding:
-            self._encoding = pyearthtools.data.transforms.attributes.set_encoding(reference=sample, limit=self._limit)
+            self._encoding = pyearthtools.data.transforms.attributes.SetEncoding(reference=sample, limit=self._limit)
         return sample
 
     def undo_func(self, sample: T) -> T:

--- a/packages/pipeline/src/pyearthtools/pipeline/operations/xarray/metadata.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/xarray/metadata.py
@@ -52,10 +52,10 @@ class Rename(Operation):
         self._rename = rename
 
     def apply_func(self, sample: xr.Dataset) -> xr.Dataset:
-        return pyearthtools.data.transforms.attributes.rename(self._rename)(sample)
+        return pyearthtools.data.transforms.attributes.Rename(self._rename)(sample)
 
     def undo_func(self, sample: xr.Dataset) -> xr.Dataset:
-        return pyearthtools.data.transforms.attributes.rename({val: key for key, val in self._rename.items()})(sample)
+        return pyearthtools.data.transforms.attributes.Rename({val: key for key, val in self._rename.items()})(sample)
 
 
 class Encoding(Operation):

--- a/packages/pipeline/src/pyearthtools/pipeline/operations/xarray/normalisation.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/xarray/normalisation.py
@@ -22,7 +22,6 @@ import xarray as xr
 
 from pyearthtools.data.utils import parse_path
 
-from pyearthtools.utils.decorators import BackwardsCompatibility
 from pyearthtools.pipeline.operation import Operation
 
 
@@ -232,10 +231,6 @@ class SingleValueDivision(xarrayNormalisation):
 
     def denormalise(self, sample):
         return sample * self.division_factor
-
-
-@BackwardsCompatibility(Division)
-def TemporalDifference(*a, **k): ...
 
 
 class Evaluated(xarrayNormalisation):

--- a/packages/pipeline/src/pyearthtools/pipeline/operations/xarray/reshape.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/xarray/reshape.py
@@ -118,4 +118,4 @@ class CoordinateFlatten(Operation):
         return pyearthtools.data.transforms.coordinates.Flatten(self.coords, skip_missing=self._skip_missing)(ds)
 
     def undo_func(self, ds):
-        return pyearthtools.data.transforms.coordinates.expand(self.coords)(ds)
+        return pyearthtools.data.transforms.coordinates.Expand(self.coords)(ds)

--- a/packages/pipeline/src/pyearthtools/pipeline/operations/xarray/select.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/xarray/select.py
@@ -52,7 +52,7 @@ class SelectDataset(Operation):
         self.variables = variables
 
     def apply_func(self, sample: xr.Dataset):
-        return pyearthtools.data.transforms.variables.trim(self.variables)(sample)
+        return pyearthtools.data.transforms.variables.Trim(self.variables)(sample)
 
 
 class DropDataset(Operation):
@@ -87,7 +87,7 @@ class DropDataset(Operation):
         self.variables = variables
 
     def apply_func(self, sample: xr.Dataset):
-        return pyearthtools.data.transforms.variables.drop(self.variables)(sample)
+        return pyearthtools.data.transforms.variables.Drop(self.variables)(sample)
 
 
 class SliceDataset(Operation):

--- a/packages/pipeline/src/pyearthtools/pipeline/operations/xarray/values.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/xarray/values.py
@@ -210,7 +210,7 @@ class Derive(Operation):
         derivation = derivation or {}
         derivation.update(derivations)
 
-        self._derive = pyearthtools.data.transforms.derive(derivation)
+        self._derive = pyearthtools.data.transforms.Derive(derivation)
         self._drop = pyearthtools.data.transform.variables.Drop(list(derivation.keys())) if drop else None
 
     def apply_func(self, sample):

--- a/packages/pipeline/src/pyearthtools/pipeline/operations/xarray/values.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/xarray/values.py
@@ -211,7 +211,7 @@ class Derive(Operation):
         derivation.update(derivations)
 
         self._derive = pyearthtools.data.transforms.derive(derivation)
-        self._drop = pyearthtools.data.transform.variables.drop(list(derivation.keys())) if drop else None
+        self._drop = pyearthtools.data.transform.variables.Drop(list(derivation.keys())) if drop else None
 
     def apply_func(self, sample):
         return self._derive(sample)

--- a/packages/training/src/pyearthtools/training/dataindex.py
+++ b/packages/training/src/pyearthtools/training/dataindex.py
@@ -33,7 +33,7 @@ from pyearthtools.data.indexes.cacheIndex import BaseCacheIndex
 
 import pyearthtools.training.wrapper
 
-ATTRIBUTE_MARK = pyearthtools.data.transforms.attributes.set_attributes(
+ATTRIBUTE_MARK = pyearthtools.data.transforms.attributes.SetAttributes(
     purpose="Research Use Only.",
     contact="For further information or support, contact the Data Science and Emerging Technologies Team.",
     crpyearthtools="Generated with `pyearthtools`, a research endeavour under the DSET team, and Project 3.1.",
@@ -170,7 +170,7 @@ class MLDataIndex(BaseCacheIndex, TimeIndex):
         # Apply attribute marks to the prediction data
         if self.data_attributes is not None:
             attrs = yaml.safe_load(open(str(self.data_attributes), "r"))
-            predictions = pyearthtools.data.transforms.attributes.set_attributes(attrs, apply_on="dataset")(predictions)
+            predictions = pyearthtools.data.transforms.attributes.SetAttributes(attrs, apply_on="dataset")(predictions)
 
         return predictions
 

--- a/packages/training/src/pyearthtools/training/wrapper/predict/__init__.py
+++ b/packages/training/src/pyearthtools/training/wrapper/predict/__init__.py
@@ -19,8 +19,6 @@
 Prediction Wrappers
 """
 
-from pyearthtools.utils.decorators import BackwardsCompatibility
-
 from pyearthtools.training.wrapper.predict.predict import Predictor
 from pyearthtools.training.wrapper.predict.timeseries import (
     TimeSeriesPredictor,
@@ -28,19 +26,3 @@ from pyearthtools.training.wrapper.predict.timeseries import (
     TimeSeriesManagedPredictor,
     ManualTimeSeriesPredictor,
 )
-
-
-@BackwardsCompatibility(TimeSeriesPredictor)
-def TimeSeriesPredictionWrapper(): ...
-
-
-@BackwardsCompatibility(TimeSeriesAutoRecurrentPredictor)
-def TimeSeriesAutoRecurrent(): ...
-
-
-@BackwardsCompatibility(TimeSeriesManagedPredictor)
-def TimeSeriesManagedRecurrent(): ...
-
-
-@BackwardsCompatibility(ManualTimeSeriesPredictor)
-def ManualTimeSeriesPredictionWrapper(): ...

--- a/packages/zoo/src/pyearthtools/zoo/model.py
+++ b/packages/zoo/src/pyearthtools/zoo/model.py
@@ -794,7 +794,7 @@ class BaseForecastModel:
             full_index_kwargs["pattern_kwargs"] = pattern_kwargs
 
         post_transforms = (
-            pyearthtools.data.transforms.attributes.set_attributes(
+            pyearthtools.data.transforms.attributes.SetAttributes(
                 pyearthtools_models=f"{self.get_name()}: {VERSION}",
                 apply_on="both",
             )

--- a/packages/zoo/src/pyearthtools/zoo/predict.py
+++ b/packages/zoo/src/pyearthtools/zoo/predict.py
@@ -215,7 +215,7 @@ def predict(  # pylint: disable=R0913
     data_cache_str = " " if data_cache is None else f" --data_cache {data_cache}"
 
     # Add a transform to add the command line to the history attributes
-    post_transforms = pyearthtools.data.transforms.attributes.set_attributes(
+    post_transforms = pyearthtools.data.transforms.attributes.SetAttributes(
         history=f"pet predict {model!r} --pipeline_name {pipeline_name!r} --output {output!s}"
         f"{f' --config_path {config_path}' if config_path else ''} "
         f"--time {time}{data_cache_str} {extra_kwargs_str}".replace("  ", " ")


### PR DESCRIPTION
### Changes

Removes BackwardsCompability uses throughout the repo.

Fixes #45.

* [X] set_attributes -> SetAttributes
* [X] set_encoding -> SetEncoding
* [X] set_type -> SetType
* [X] rename -> Rename
* [X] interpolate_na -> InterpolateNan
* [X] force_standard_dimension_names -> StandardDimensionNames
* [X] expand -> Expand
* [X] derive -> Derive
* [X] rechunk -> Rechunk
* [X] TimeSeriesPredictionWrapper -> TimeSeriesPredictor
* [X] TimeSeriesAutoRecurrent -> TimeSeriesAutoRecurrentPredictor
* [X] TimeSeriesManagedRecurrent -> TimeSeriesManagedPredictor
* [X] ManualTimeSeriesPredictionWrapper -> ManualTimeSeriesPredictor
* [X] TemporalDifference -> Division
* [X] fill -> Fill
* [X] sel -> Select
* [X] isel -> ISelect
* [X] point_box -> PointBox
* [X] lookup -> Lookup
* [X] from_shapefile -> ShapeFile
* [X] from_geosearch -> Geosearch
* [X] pad -> Pad
* [X] dataset -> Dataset
* [X] replace_value -> Replace
* [X] trim -> Trim
* [X] variable_trim -> Trim
* [X] drop -> Drop

### Testing

Test suite was run locally after every commit.