### PR TITLE
Add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ If you are thinking about contributing some code to PyEarthTools, you are very w
 - Improve documentation and tutorials based on your own experience
 - Contribute to code quality and test coverage
 
-(A pinned issue)[https://github.com/ACCESS-Community-Hub/PyEarthTools/issues/174] contains a non-exhaustive list of things you could consider doing. Alternatively, you are very welcome to look through the GitHub issue tracker and see if there is anything that grabs your interest. If you are going to work on an issue, let me know so we can avoid people doubling up.
+[A pinned issue](https://github.com/ACCESS-Community-Hub/PyEarthTools/issues/174) contains a non-exhaustive list of things you could consider doing. Alternatively, you are very welcome to look through the GitHub issue tracker and see if there is anything that grabs your interest. If you are going to work on an issue, let me know so we can avoid people doubling up.
 
 
 ## Getting Started

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# How to Contribe to PyEarthTools
+
+If you are thinking about contributing some code to PyEarthTools, you are very welcome. There are many ways you can help to improve PyEarthTools, for example
+
+- Raise bugs and feature requests in the [GitHub issue tracker](https://github.com/ACCESS-Community-Hub/PyEarthTools/issues)
+- Improve documentation and tutorials based on your own experience
+- Contribute to code quality and test coverage
+
+(A pinned issue)[https://github.com/ACCESS-Community-Hub/PyEarthTools/issues/174] contains a non-exhaustive list of things you could consider doing. Alternatively, you are very welcome to look through the GitHub issue tracker and see if there is anything that grabs your interest. If you are going to work on an issue, let me know so we can avoid people doubling up.
+
+
+## Getting Started
+
+To learn more about PyEarthTools in general, a good place to start is: https://pyearthtools.readthedocs.io/en/latest/newuser.html
+
+If you think you may want to contribute code, you will need to follow the PyEarthTools installation instructions here: https://pyearthtools.readthedocs.io/en/latest/installation.html#developer-installation and read the developer guide here: https://pyearthtools.readthedocs.io/en/latest/devguide.html .
+
+
+## Contribution Workflow
+
+Details of the contribution workflow can be found in the [Developer Guide](docs/devguide.md), including
+
+- Forking the repository in GitHub,
+- Submitting changes via pull requests from your own fork,
+- Code reviews
+- Coding formatting and test coverage requirements
+- GitHub actions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ If you think you may want to contribute code, you will need to follow the PyEart
 
 ## Contribution Workflow
 
-Details of the contribution workflow can be found in the [Developer Guide](docs/devguide.md), including
+Details of the contribution workflow can be found in the [Developer Guide](https://pyearthtools.readthedocs.io/en/latest/devguide.html), including
 
 - Forking the repository in GitHub,
 - Submitting changes via pull requests from your own fork,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,9 +11,9 @@ If you are thinking about contributing some code to PyEarthTools, you are very w
 
 ## Getting Started
 
-To learn more about PyEarthTools in general, a good place to start is: https://pyearthtools.readthedocs.io/en/latest/newuser.html
+To learn more about PyEarthTools in general, a good place to start is the [New Users Guide](https://pyearthtools.readthedocs.io/en/latest/newuser.html)
 
-If you think you may want to contribute code, you will need to follow the PyEarthTools installation instructions here: https://pyearthtools.readthedocs.io/en/latest/installation.html#developer-installation and read the developer guide here: https://pyearthtools.readthedocs.io/en/latest/devguide.html .
+If you think you may want to contribute code, you will need to follow the PyEarthTools installation instructions [here](https://pyearthtools.readthedocs.io/en/latest/installation.html#developer-installation) and read the developer guide [here](https://pyearthtools.readthedocs.io/en/latest/devguide.html) .
 
 
 ## Contribution Workflow

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -11,7 +11,7 @@ If you are thinking about contributing some code to PyEarthTools, you are very w
 
 ## Getting Started
 
-To learn more about PyEarthTools in general, a good place to start is the [New Users Guide](https://pyearthtools.readthedocs.io/en/latest/newuser.html)
+To learn more about PyEarthTools in general, a good place to start is the [New Users Guide](https://pyearthtools.readthedocs.io/en/latest/newuser.html) .
 
 If you think you may want to contribute code, you will need to follow the PyEarthTools installation instructions [here](https://pyearthtools.readthedocs.io/en/latest/installation.html#developer-installation) and read the developer guide [here](https://pyearthtools.readthedocs.io/en/latest/devguide.html) .
 

--- a/docs/devguide.md
+++ b/docs/devguide.md
@@ -18,7 +18,7 @@ This is a summary only, and should be expanded to provide more detail. This is i
 - Pylint checking is a good idea, please turn it on and do your best.
 
 
-## Creating Your Own Fork  of PyEarthTools for the First Time
+## Creating Your Own Fork of PyEarthTools for the First Time
 
 Unless you are an advanced Git user, we would recommend you follow this process:
 


### PR DESCRIPTION
GitHub prefers to have an onboarding document at the top level of the repo called CONTRIBUTING.md. One benefit is that you get a "Contributing" tab in the readme area on the project home page, i.e.
https://github.com/lukehoffmann/PyEarthTools/tree/contributing?tab=contributing-ov-file#

See GitHub documentation [Setting guidelines for repository contributors](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/setting-guidelines-for-repository-contributors)

This adds a simple document, which will initially be mostly links to other documentation