### PR TITLE
Add default entries in Catalog and more tests

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -89,6 +89,11 @@
       "orcid": "https://orcid.org/0009-0006-3272-3678",
       "affiliation": "Bureau of Meteorology, Australia",
       "name": "Hoffmann, Luke"
+    },
+    {
+      "orcid": "https://orcid.org/0009-0001-3652-4274",
+      "affiliation": "Bureau of Meteorology, Australia",
+      "name": "Pegios, Michael"
     }
   ],
   "license": "Apache-2.0",

--- a/packages/data/src/pyearthtools/data/catalog.py
+++ b/packages/data/src/pyearthtools/data/catalog.py
@@ -373,7 +373,7 @@ class Catalog:
     a dictionary with the init kwargs. A `name` kwarg specifies the `CatalogEntry` name.
     """
 
-    def __init__(self, *, catalog_name: Optional[str] = None, entries=Optional[dict]):
+    def __init__(self, *, catalog_name: Optional[str] = None, entries: Optional[dict] = None):
         """
         Initalise a new Catalog of Data Sources
 
@@ -398,8 +398,9 @@ class Catalog:
 
         self.name = catalog_name
 
-        for name, entry in entries.items():
-            self.append(entry, name=name)
+        if entries:
+            for name, entry in entries.items():
+                self.append(entry, name=name)
 
     def append(
         self,

--- a/packages/data/tests/test_catalog.py
+++ b/packages/data/tests/test_catalog.py
@@ -14,13 +14,17 @@
 
 import pyearthtools
 from pyearthtools.data import catalog
+from pyearthtools.utils.initialisation import imports
 from collections import namedtuple
 import pytest
 import io
+from types import ModuleType
 
 
 def test_get_name():
-
+    """
+    Test the test_get_name functionality
+    """
     result = catalog.get_name("testname")
     assert result == "testname"
 
@@ -103,3 +107,57 @@ def test_Catalog():
     cat.remove("TestEntryKey")
     with pytest.raises(KeyError):
         popped = cat.remove("TestEntryKey")
+
+
+def test_CatalogEntry_Nones():
+    class mockEntry:
+        def __init__(self, x, kwarg_1):
+            self.item_class = None
+            self.x = x
+            self.kwarg_1 = kwarg_1
+
+    mockEntry("x", "kwarg1")
+
+    # Test item_class with "String" instance
+    ce = catalog.CatalogEntry("None", args=["None"], name=["None"], kwargs={"my_kwarg": "None"})
+    assert ce.item_class is None  # Test item_class set to None
+
+    ce = catalog.CatalogEntry("pytest", args=["None"], name=["None"], kwargs={"my_kwarg": "None"})
+    assert isinstance(ce.item_class, ModuleType)  # Test item_class dynamic import work
+
+    ce = catalog.CatalogEntry(mockEntry, args=["None"], name=["None"], kwargs={"my_kwarg": "None"})
+    args = ce.to_dict()["args"]
+    kwargs = ce.to_dict()["kwargs"]
+    assert args[0] is None  # Test str to None conversion for args
+    assert kwargs["my_kwarg"] is None  # Test str to None conversion for kwargs
+
+
+def test_CatalogEntry_Save_and_Load(monkeypatch, tmpdir):
+    class mock_callable:
+        def __init__(self, _x):
+            return None
+
+        def mock_callable(self):
+            return "Class has a method with the same name for dynamic importing save/load!"
+
+    tmp_path = tmpdir.mkdir("sub").join("cat.tmp")
+    tmp_path = tmp_path.strpath
+
+    monkeypatch.setattr(imports, "dynamic_import", mock_callable)
+
+    test_mock_callable = mock_callable("x")
+    assert isinstance(test_mock_callable.mock_callable(), str)
+
+    ce = catalog.CatalogEntry(mock_callable, args=["X"])
+    cat = catalog.Catalog(catalog_name="smart_test_catalog", entries={"foo": ce})
+    cat.save(tmp_path)
+    loaded_cat = cat.load(tmp_path)
+
+    cat_dict = cat.to_dict()
+    loaded_cat_dict = loaded_cat.to_dict()
+
+    first_cat_key = list(cat_dict.keys())[0]
+    first_loaded_cat_key = list(loaded_cat_dict.keys())[0]
+
+    # Assert that we were able to load in the same data as what was saved...
+    assert loaded_cat_dict[first_loaded_cat_key]["args"] == cat_dict[first_cat_key]["args"]


### PR DESCRIPTION
Add further tests for test_catalog:

* Tests saving and loading functionality
* Edge cases testing None strings/objects

Add default entries in Catalog class definition:

* Entries were put down as optional, but entries.items() is called on the variable.
* Setting the default to {} fixes the issue.
* This is important in Catalog.load() that instantiates this class without any arguments.