### PR TITLE
Remove last known uses of the backwards compatibility decorator

### DIFF
--- a/packages/pipeline/src/pyearthtools/pipeline/operations/xarray/reshape.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/xarray/reshape.py
@@ -238,4 +238,3 @@ class CoordinateExpand(Operation):
 
     def undo_func(self, ds):
         return pyearthtools.pipeline.operations.xarray.reshape.CoordinateFlatten(self._coordinate)(ds)
-

--- a/packages/pipeline/src/pyearthtools/pipeline/operations/xarray/reshape.py
+++ b/packages/pipeline/src/pyearthtools/pipeline/operations/xarray/reshape.py
@@ -23,7 +23,6 @@ from pyearthtools.data.transforms.coordinates import Drop
 from pyearthtools.pipeline.operation import Operation
 
 from pyearthtools.data.transforms.attributes import SetType
-from pyearthtools.utils.decorators import BackwardsCompatibility
 
 T = TypeVar("T", xr.Dataset, xr.DataArray)
 
@@ -185,11 +184,7 @@ class CoordinateFlatten(Operation):
         return new_ds
 
     def undo_func(self, ds):
-        return pyearthtools.pipeline.operations.xarray.reshape.coordinate_expand(self._coordinate)(ds)
-
-
-@BackwardsCompatibility(CoordinateFlatten)
-def coordinate_flatten(*args, **kwargs) -> Operation: ...
+        return pyearthtools.pipeline.operations.xarray.reshape.CoordinateExpand(self._coordinate)(ds)
 
 
 class CoordinateExpand(Operation):
@@ -242,8 +237,5 @@ class CoordinateExpand(Operation):
         return dataset
 
     def undo_func(self, ds):
-        return pyearthtools.pipeline.operations.xarray.reshape.coordinate_flatten(self._coordinate)(ds)
+        return pyearthtools.pipeline.operations.xarray.reshape.CoordinateFlatten(self._coordinate)(ds)
 
-
-@BackwardsCompatibility(CoordinateExpand)
-def coordinate_expand(*args, **kwargs) -> Operation: ...

--- a/packages/utils/src/pyearthtools/utils/decorators.py
+++ b/packages/utils/src/pyearthtools/utils/decorators.py
@@ -94,33 +94,3 @@ def alias_arguments(**aliases: str | list[str]) -> Callable[[C], C]:
     return internal_function
 
 
-def BackwardsCompatibility(new_func: C) -> Callable[[C], C]:
-    """
-    Allows for the renaming of a functionality, and subsequent backwards compatilbility.
-
-    Will warn about deprecation on use.
-
-    Args:
-        new_func:
-            New function to point to instead
-
-    Example:
-        >>> def new_func(): # New function name
-            ...
-        >>> @BackwardsCompatibility(new_func)
-        >>> def old_func(*a, **kw):
-            ...
-
-    """
-
-    def decorator(func: C) -> C:
-        def wrapped(*args, **kwargs):
-            warnings.warn(
-                f"{func.__name__} has been removed in favour of {new_func.__name__}, please switch over.",
-                DeprecationWarning,
-            )
-            return new_func(*args, **kwargs)
-
-        return wrapped
-
-    return decorator

--- a/packages/utils/src/pyearthtools/utils/decorators.py
+++ b/packages/utils/src/pyearthtools/utils/decorators.py
@@ -16,7 +16,6 @@
 from __future__ import annotations
 
 import functools
-import warnings
 from typing import Any, Callable, TypeVar
 
 C = TypeVar("C", bound=Callable[..., Any])
@@ -92,5 +91,3 @@ def alias_arguments(**aliases: str | list[str]) -> Callable[[C], C]:
         return wrapper
 
     return internal_function
-
-


### PR DESCRIPTION
Remove the decorator code


 - [ x ] If no generative AI was used, then tick this box

 - [ x ] Mark the PR as ready to review. Note - we encourage you to ask for feedback at the outset or at any time during the work.
